### PR TITLE
Add support for BlockFrost and Ogmios-Kupo backends

### DIFF
--- a/example.py
+++ b/example.py
@@ -8,18 +8,17 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from pycardano import Address, Network
 
 from charli3_dendrite import SundaeSwapCPPState
+from charli3_dendrite.backend import DbsyncBackend
 from charli3_dendrite.backend import get_backend
 from charli3_dendrite.backend import set_backend
-from charli3_dendrite.backend import DbsyncBackend, OgmiosKupoBackend, BlockFrostBackend
+from charli3_dendrite.dataclasses.models import Assets
 from charli3_dendrite.dexs.amm.amm_base import AbstractPoolState
 from charli3_dendrite.dexs.core.errors import InvalidLPError
 from charli3_dendrite.dexs.core.errors import InvalidPoolError
 from charli3_dendrite.dexs.core.errors import NoAssetsError
-from charli3_dendrite.dataclasses.models import Assets
-
+from pycardano import Address
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -46,7 +45,7 @@ def save_to_file(data: Dict[str, Any], filename: str = "blockchain_data.json") -
 
 
 def test_get_pool_utxos(
-    backend: DbsyncBackend, dex: type[AbstractPoolState]
+    backend: DbsyncBackend, dex: type[AbstractPoolState],
 ) -> Dict[str, Any]:
     """Test get_pool_utxos function."""
     logger.info("Testing get_pool_utxos for %s...", dex.__name__)
@@ -65,7 +64,7 @@ def test_get_pool_utxos(
     assets = existing_assets + [specific_asset]
 
     result = backend.get_pool_utxos(
-        limit=10000, historical=False, assets=assets, **selector_dict
+        limit=10000, historical=False, assets=assets, **selector_dict,
     )
 
     pool_data = {}
@@ -183,7 +182,7 @@ def test_get_cancel_utxos(backend: DbsyncBackend) -> List[Dict[str, Any]]:
     ]
     after_time = datetime.now() - timedelta(hours=1)  # Look at last hour
     result = backend.get_cancel_utxos(
-        stake_addresses, after_time=after_time, limit=1000
+        stake_addresses, after_time=after_time, limit=1000,
     )
     logger.info("Found %d cancel UTXOs", len(result))
     return [utxo.model_dump() for utxo in result]
@@ -193,7 +192,7 @@ def test_get_axo_target(backend: DbsyncBackend) -> Optional[str]:
     """Test get_axo_target function for both backends."""
     logger.info("Testing get_axo_target...")
     assets = Assets(
-        root={"f13ac4d66b3ee19a6aa0f2a22298737bd907cc95121662fc971b5275535452494b45": 1}
+        root={"f13ac4d66b3ee19a6aa0f2a22298737bd907cc95121662fc971b5275535452494b45": 1},
     )
     result = backend.get_axo_target(assets)
     logger.info("found at %s", result)
@@ -247,7 +246,7 @@ def main() -> None:
         all_data["axo_target"] = test_get_axo_target(backend)
     except NotImplementedError as e:
         logger.warning(
-            "Some methods are not implemented for the current backend: %s", e
+            "Some methods are not implemented for the current backend: %s", e,
         )
 
     # Save all collected data to a file

--- a/example.py
+++ b/example.py
@@ -246,7 +246,9 @@ def main() -> None:
         all_data["cancel_utxos"] = test_get_cancel_utxos(backend)
         all_data["axo_target"] = test_get_axo_target(backend)
     except NotImplementedError as e:
-        logger.warning("Some methods are not implemented for the current backend: %s", e)
+        logger.warning(
+            "Some methods are not implemented for the current backend: %s", e
+        )
 
     # Save all collected data to a file
     save_to_file(all_data)

--- a/example.py
+++ b/example.py
@@ -45,7 +45,8 @@ def save_to_file(data: Dict[str, Any], filename: str = "blockchain_data.json") -
 
 
 def test_get_pool_utxos(
-    backend: DbsyncBackend, dex: type[AbstractPoolState],
+    backend: DbsyncBackend,
+    dex: type[AbstractPoolState],
 ) -> Dict[str, Any]:
     """Test get_pool_utxos function."""
     logger.info("Testing get_pool_utxos for %s...", dex.__name__)
@@ -64,7 +65,10 @@ def test_get_pool_utxos(
     assets = existing_assets + [specific_asset]
 
     result = backend.get_pool_utxos(
-        limit=10000, historical=False, assets=assets, **selector_dict,
+        limit=10000,
+        historical=False,
+        assets=assets,
+        **selector_dict,
     )
 
     pool_data = {}
@@ -182,7 +186,9 @@ def test_get_cancel_utxos(backend: DbsyncBackend) -> List[Dict[str, Any]]:
     ]
     after_time = datetime.now() - timedelta(hours=1)  # Look at last hour
     result = backend.get_cancel_utxos(
-        stake_addresses, after_time=after_time, limit=1000,
+        stake_addresses,
+        after_time=after_time,
+        limit=1000,
     )
     logger.info("Found %d cancel UTXOs", len(result))
     return [utxo.model_dump() for utxo in result]
@@ -192,7 +198,9 @@ def test_get_axo_target(backend: DbsyncBackend) -> Optional[str]:
     """Test get_axo_target function for both backends."""
     logger.info("Testing get_axo_target...")
     assets = Assets(
-        root={"f13ac4d66b3ee19a6aa0f2a22298737bd907cc95121662fc971b5275535452494b45": 1},
+        root={
+            "f13ac4d66b3ee19a6aa0f2a22298737bd907cc95121662fc971b5275535452494b45": 1,
+        },
     )
     result = backend.get_axo_target(assets)
     logger.info("found at %s", result)
@@ -246,7 +254,8 @@ def main() -> None:
         all_data["axo_target"] = test_get_axo_target(backend)
     except NotImplementedError as e:
         logger.warning(
-            "Some methods are not implemented for the current backend: %s", e,
+            "Some methods are not implemented for the current backend: %s",
+            e,
         )
 
     # Save all collected data to a file

--- a/example.py
+++ b/example.py
@@ -4,21 +4,22 @@ import json
 import logging
 from datetime import datetime
 from datetime import timedelta
+from pathlib import Path
 from typing import Any
-from typing import Dict
-from typing import List
 from typing import Optional
 
-from charli3_dendrite import SundaeSwapCPPState
-from charli3_dendrite.backend import DbsyncBackend
+from charli3_dendrite import SundaeSwapCPPState  # type: ignore
+from charli3_dendrite.backend import DbsyncBackend  # type: ignore
+from charli3_dendrite.backend import Network  # type: ignore
+from charli3_dendrite.backend import OgmiosKupoBackend  # type: ignore
 from charli3_dendrite.backend import get_backend
 from charli3_dendrite.backend import set_backend
-from charli3_dendrite.dataclasses.models import Assets
-from charli3_dendrite.dexs.amm.amm_base import AbstractPoolState
-from charli3_dendrite.dexs.core.errors import InvalidLPError
+from charli3_dendrite.dataclasses.models import Assets  # type: ignore
+from charli3_dendrite.dexs.amm.amm_base import AbstractPoolState  # type: ignore
+from charli3_dendrite.dexs.core.errors import InvalidLPError  # type: ignore
 from charli3_dendrite.dexs.core.errors import InvalidPoolError
 from charli3_dendrite.dexs.core.errors import NoAssetsError
-from pycardano import Address
+from pycardano import Address  # type: ignore
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -27,27 +28,27 @@ logging.basicConfig(
 )
 logger = logging.getLogger("charli3_dendrite")
 
-DEXS: List[type[AbstractPoolState]] = [
+DEXS: list[type[AbstractPoolState]] = [
     SundaeSwapCPPState,
     # MinswapV2CPPState,
     # Add other DEX states here
 ]
 
 
-def save_to_file(data: Dict[str, Any], filename: str = "blockchain_data.json") -> None:
+def save_to_file(data: dict[str, Any], filename: str = "blockchain_data.json") -> None:
     """Save the blockchain data to a local file."""
     try:
-        with open(filename, "w", encoding="utf-8") as f:
+        with Path(filename).open("w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
         logger.info("Data successfully saved to %s", filename)
-    except Exception as e:
+    except OSError as e:
         logger.error("Error saving data to file: %s", e)
 
 
 def test_get_pool_utxos(
     backend: DbsyncBackend,
     dex: type[AbstractPoolState],
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Test get_pool_utxos function."""
     logger.info("Testing get_pool_utxos for %s...", dex.__name__)
     selector = dex.pool_selector()
@@ -62,7 +63,7 @@ def test_get_pool_utxos(
     specific_asset = (
         "8e51398904a5d3fc129fbf4f1589701de23c7824d5c90fdb9490e15a434841524c4933"
     )
-    assets = existing_assets + [specific_asset]
+    assets = [*existing_assets, specific_asset]
 
     result = backend.get_pool_utxos(
         limit=10000,
@@ -80,16 +81,14 @@ def test_get_pool_utxos(
                 "fee": d.fee,
                 "last_update": d.block_time,
             }
-        except (NoAssetsError, InvalidLPError, InvalidPoolError):
-            pass
-        except Exception as e:
-            logger.debug("%s: %s", dex.__name__, e)
+        except (NoAssetsError, InvalidLPError, InvalidPoolError) as e:
+            logger.warning("Invalid pool data found: %s", e)
 
     logger.info("Found %d pools for %s", len(pool_data), dex.__name__)
     return pool_data
 
 
-def test_get_pool_in_tx(backend: DbsyncBackend) -> List[Dict[str, Any]]:
+def test_get_pool_in_tx(backend: DbsyncBackend) -> list[dict[str, Any]]:
     """Test get_pool_in_tx function."""
     logger.info("Testing get_pool_in_tx...")
     tx_hash = "14e59f304767ea9a659fe3dce74c1ea3837652b5008fab0bd6c56b023ad3f227"
@@ -99,7 +98,7 @@ def test_get_pool_in_tx(backend: DbsyncBackend) -> List[Dict[str, Any]]:
     return [pool.model_dump() for pool in result]
 
 
-def test_last_block(backend: DbsyncBackend) -> List[Dict[str, Any]]:
+def test_last_block(backend: DbsyncBackend) -> list[dict[str, Any]]:
     """Test last_block function."""
     logger.info("Testing last_block...")
     blocks = backend.last_block(last_n_blocks=2)
@@ -108,7 +107,7 @@ def test_last_block(backend: DbsyncBackend) -> List[Dict[str, Any]]:
     return block_data
 
 
-def test_get_pool_utxos_in_block(backend: DbsyncBackend) -> List[Dict[str, Any]]:
+def test_get_pool_utxos_in_block(backend: DbsyncBackend) -> list[dict[str, Any]]:
     """Test get_pool_utxos_in_block function."""
     logger.info("Testing get_pool_utxos_in_block...")
     blocks = backend.last_block(last_n_blocks=1)
@@ -119,7 +118,7 @@ def test_get_pool_utxos_in_block(backend: DbsyncBackend) -> List[Dict[str, Any]]
     return [pool.model_dump() for pool in result[:10]]  # Return first 10 for brevity
 
 
-def test_get_script_from_address(backend: DbsyncBackend) -> Dict[str, Any]:
+def test_get_script_from_address(backend: DbsyncBackend) -> dict[str, Any]:
     """Test get_script_from_address function."""
     logger.info("Testing get_script_from_address...")
     address = Address.from_primitive(
@@ -130,7 +129,7 @@ def test_get_script_from_address(backend: DbsyncBackend) -> Dict[str, Any]:
     return result.model_dump()
 
 
-def test_get_datum_from_address(backend: DbsyncBackend) -> Optional[Dict[str, Any]]:
+def test_get_datum_from_address(backend: DbsyncBackend) -> Optional[dict[str, Any]]:
     """Test get_datum_from_address function."""
     logger.info("Testing get_datum_from_address...")
     address = Address.from_primitive(
@@ -144,7 +143,7 @@ def test_get_datum_from_address(backend: DbsyncBackend) -> Optional[Dict[str, An
     return None
 
 
-def test_get_historical_order_utxos(backend: DbsyncBackend) -> List[Dict[str, Any]]:
+def test_get_historical_order_utxos(backend: DbsyncBackend) -> list[dict[str, Any]]:
     """Test get_historical_order_utxos function."""
     logger.info("Testing get_historical_order_utxos...")
     stake_addresses = [
@@ -160,7 +159,7 @@ def test_get_historical_order_utxos(backend: DbsyncBackend) -> List[Dict[str, An
     return [utxo.model_dump() for utxo in result]
 
 
-def test_get_order_utxos_by_block_or_tx(backend: DbsyncBackend) -> List[Dict[str, Any]]:
+def test_get_order_utxos_by_block_or_tx(backend: DbsyncBackend) -> list[dict[str, Any]]:
     """Test get_order_utxos_by_block_or_tx function."""
     logger.info("Testing get_order_utxos_by_block_or_tx...")
     stake_addresses = [
@@ -178,7 +177,7 @@ def test_get_order_utxos_by_block_or_tx(backend: DbsyncBackend) -> List[Dict[str
     return [utxo.model_dump() for utxo in result]
 
 
-def test_get_cancel_utxos(backend: DbsyncBackend) -> List[Dict[str, Any]]:
+def test_get_cancel_utxos(backend: DbsyncBackend) -> list[dict[str, Any]]:
     """Test get_cancel_utxos function."""
     logger.info("Testing get_cancel_utxos...")
     stake_addresses = [
@@ -212,46 +211,49 @@ def main() -> None:
     # Choose one of the following backends:
 
     # 1. DbsyncBackend (full functionality)
-    set_backend(DbsyncBackend())
+    # ruff: noqa: ERA001
+    # set_backend(DbsyncBackend())
 
     # 2. OgmiosKupoBackend (some methods may not be implemented)
-    # set_backend(
-    #     OgmiosKupoBackend(
-    #         ogmios_url="ws://ogmios-url-here",
-    #         kupo_url="http://kupo-url-here",
-    #         network=Network.MAINNET,
-    #     )
-    # )
+    # ruff: noqa: ERA001
+    set_backend(
+        OgmiosKupoBackend(
+            ogmios_url="ws://35.247.13.90:1337",
+            kupo_url="http://35.247.13.90:1442",
+            network=Network.MAINNET,
+        ),
+    )
 
     # 3. BlockFrostBackend (some methods may not be implemented)
-    # set_backend(BlockFrostBackend("your-project-id-here"))
+    # set_backend(BlockFrostBackend("mainnetVs1Kwtk4Iz04ll4zSBINbLHeT7up0tHN"))
 
     # Note: BlockFrost and Ogmios-Kupo backends may raise NotImplementedError
     # for methods like get_historical_order_utxos, get_order_utxos_by_block_or_tx,
     # and get_cancel_utxos due to limitations in their respective APIs.
 
     backend = get_backend()
-    all_data: Dict[str, Any] = {}
+    all_data: dict[str, Any] = {}
 
     # Test get_pool_utxos for each DEX
-    for dex in DEXS:
-        all_data[f"pool_utxos_{dex.__name__}"] = test_get_pool_utxos(backend, dex)
+    # for dex in DEXS:
+    #     all_data[f"pool_utxos_{dex.__name__}"] = test_get_pool_utxos(backend, dex)
 
     # Test other functions
-    all_data["pool_in_tx"] = test_get_pool_in_tx(backend)
-    all_data["last_blocks"] = test_last_block(backend)
-    all_data["pool_utxos_in_block"] = test_get_pool_utxos_in_block(backend)
+    # all_data["pool_in_tx"] = test_get_pool_in_tx(backend)
+    # all_data["last_blocks"] = test_last_block(backend)
+    # all_data["pool_utxos_in_block"] = test_get_pool_utxos_in_block(backend)
     all_data["script_from_address"] = test_get_script_from_address(backend)
     datum_result = test_get_datum_from_address(backend)
     if datum_result is not None:
         all_data["datum_from_address"] = datum_result
 
-    # The following methods may raise NotImplementedError for BlockFrost and Ogmios-Kupo backends
+    # The following methods may raise NotImplementedError
+    # for BlockFrost and Ogmios-Kupo backends
     try:
+        all_data["axo_target"] = test_get_axo_target(backend)
         all_data["historical_order_utxos"] = test_get_historical_order_utxos(backend)
         all_data["order_utxos_by_block"] = test_get_order_utxos_by_block_or_tx(backend)
         all_data["cancel_utxos"] = test_get_cancel_utxos(backend)
-        all_data["axo_target"] = test_get_axo_target(backend)
     except NotImplementedError as e:
         logger.warning(
             "Some methods are not implemented for the current backend: %s",

--- a/example.py
+++ b/example.py
@@ -218,8 +218,8 @@ def main() -> None:
     # ruff: noqa: ERA001
     set_backend(
         OgmiosKupoBackend(
-            ogmios_url="ws://35.247.13.90:1337",
-            kupo_url="http://35.247.13.90:1442",
+            ogmios_url="ws://ogmios-url:1337",
+            kupo_url="http://kupo-url:1442",
             network=Network.MAINNET,
         ),
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -114,14 +114,29 @@ files = [
 
 [[package]]
 name = "cachetools"
-version = "5.4.0"
+version = "5.5.0"
 description = "Extensible memoizing collections and decorators"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cachetools-5.4.0-py3-none-any.whl", hash = "sha256:3ae3b49a3d5e28a77a0be2b37dbcb89005058959cb2323858c2657c4a8cab474"},
-    {file = "cachetools-5.4.0.tar.gz", hash = "sha256:b8adc2e7c07f105ced7bc56dbb6dfbe7c4a00acce20e2227b3f355be89bc6827"},
+    {file = "cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292"},
+    {file = "cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a"},
 ]
+
+[[package]]
+name = "cardano-tools"
+version = "2.1.0"
+description = "A collection of tools to enable development in the Cardano ecosystem using the Python programming language."
+optional = false
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "cardano_tools-2.1.0-py3-none-any.whl", hash = "sha256:c562c234b3d9a51540d41432f88aeae9a68c9441e0ea363c675dd712380ca06c"},
+    {file = "cardano_tools-2.1.0.tar.gz", hash = "sha256:445c8a5c769f57e5e04494ac4e3012082c3d0f1bd9a9eaed7f834d37ad7a069e"},
+]
+
+[package.dependencies]
+pexpect = ">=4.8.0,<5.0.0"
+requests = ">=2.28.0,<3.0.0"
 
 [[package]]
 name = "cbor2"
@@ -413,6 +428,23 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+
+[[package]]
+name = "coloredlogs"
+version = "15.0.1"
+description = "Colored terminal output for Python's logging module"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934"},
+    {file = "coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0"},
+]
+
+[package.dependencies]
+humanfriendly = ">=9.1"
+
+[package.extras]
+cron = ["capturer (>=2.4)"]
 
 [[package]]
 name = "cose"
@@ -732,6 +764,20 @@ files = [
 ]
 
 [[package]]
+name = "humanfriendly"
+version = "10.0"
+description = "Human friendly output for text interfaces using Python"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477"},
+    {file = "humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"},
+]
+
+[package.dependencies]
+pyreadline3 = {version = "*", markers = "sys_platform == \"win32\" and python_version >= \"3.8\""}
+
+[[package]]
 name = "identify"
 version = "2.6.0"
 description = "File identification library for Python"
@@ -747,13 +793,13 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.7"
+version = "3.8"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 files = [
-    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
-    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
+    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
 ]
 
 [[package]]
@@ -805,38 +851,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.11.1"
+version = "1.11.2"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.11.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a32fc80b63de4b5b3e65f4be82b4cfa362a46702672aa6a0f443b4689af7008c"},
-    {file = "mypy-1.11.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c1952f5ea8a5a959b05ed5f16452fddadbaae48b5d39235ab4c3fc444d5fd411"},
-    {file = "mypy-1.11.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1e30dc3bfa4e157e53c1d17a0dad20f89dc433393e7702b813c10e200843b03"},
-    {file = "mypy-1.11.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2c63350af88f43a66d3dfeeeb8d77af34a4f07d760b9eb3a8697f0386c7590b4"},
-    {file = "mypy-1.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:a831671bad47186603872a3abc19634f3011d7f83b083762c942442d51c58d58"},
-    {file = "mypy-1.11.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7b6343d338390bb946d449677726edf60102a1c96079b4f002dedff375953fc5"},
-    {file = "mypy-1.11.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e4fe9f4e5e521b458d8feb52547f4bade7ef8c93238dfb5bbc790d9ff2d770ca"},
-    {file = "mypy-1.11.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:886c9dbecc87b9516eff294541bf7f3655722bf22bb898ee06985cd7269898de"},
-    {file = "mypy-1.11.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fca4a60e1dd9fd0193ae0067eaeeb962f2d79e0d9f0f66223a0682f26ffcc809"},
-    {file = "mypy-1.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:0bd53faf56de9643336aeea1c925012837432b5faf1701ccca7fde70166ccf72"},
-    {file = "mypy-1.11.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f39918a50f74dc5969807dcfaecafa804fa7f90c9d60506835036cc1bc891dc8"},
-    {file = "mypy-1.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0bc71d1fb27a428139dd78621953effe0d208aed9857cb08d002280b0422003a"},
-    {file = "mypy-1.11.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b868d3bcff720dd7217c383474008ddabaf048fad8d78ed948bb4b624870a417"},
-    {file = "mypy-1.11.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a707ec1527ffcdd1c784d0924bf5cb15cd7f22683b919668a04d2b9c34549d2e"},
-    {file = "mypy-1.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:64f4a90e3ea07f590c5bcf9029035cf0efeae5ba8be511a8caada1a4893f5525"},
-    {file = "mypy-1.11.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:749fd3213916f1751fff995fccf20c6195cae941dc968f3aaadf9bb4e430e5a2"},
-    {file = "mypy-1.11.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b639dce63a0b19085213ec5fdd8cffd1d81988f47a2dec7100e93564f3e8fb3b"},
-    {file = "mypy-1.11.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c956b49c5d865394d62941b109728c5c596a415e9c5b2be663dd26a1ff07bc0"},
-    {file = "mypy-1.11.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:45df906e8b6804ef4b666af29a87ad9f5921aad091c79cc38e12198e220beabd"},
-    {file = "mypy-1.11.1-cp38-cp38-win_amd64.whl", hash = "sha256:d44be7551689d9d47b7abc27c71257adfdb53f03880841a5db15ddb22dc63edb"},
-    {file = "mypy-1.11.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2684d3f693073ab89d76da8e3921883019ea8a3ec20fa5d8ecca6a2db4c54bbe"},
-    {file = "mypy-1.11.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:79c07eb282cb457473add5052b63925e5cc97dfab9812ee65a7c7ab5e3cb551c"},
-    {file = "mypy-1.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11965c2f571ded6239977b14deebd3f4c3abd9a92398712d6da3a772974fad69"},
-    {file = "mypy-1.11.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a2b43895a0f8154df6519706d9bca8280cda52d3d9d1514b2d9c3e26792a0b74"},
-    {file = "mypy-1.11.1-cp39-cp39-win_amd64.whl", hash = "sha256:1a81cf05975fd61aec5ae16501a091cfb9f605dc3e3c878c0da32f250b74760b"},
-    {file = "mypy-1.11.1-py3-none-any.whl", hash = "sha256:0624bdb940255d2dd24e829d99a13cfeb72e4e9031f9492148f410ed30bcab54"},
-    {file = "mypy-1.11.1.tar.gz", hash = "sha256:f404a0b069709f18bbdb702eb3dcfe51910602995de00bd39cea3050b5772d08"},
+    {file = "mypy-1.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d42a6dd818ffce7be66cce644f1dff482f1d97c53ca70908dff0b9ddc120b77a"},
+    {file = "mypy-1.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:801780c56d1cdb896eacd5619a83e427ce436d86a3bdf9112527f24a66618fef"},
+    {file = "mypy-1.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41ea707d036a5307ac674ea172875f40c9d55c5394f888b168033177fce47383"},
+    {file = "mypy-1.11.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6e658bd2d20565ea86da7d91331b0eed6d2eee22dc031579e6297f3e12c758c8"},
+    {file = "mypy-1.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:478db5f5036817fe45adb7332d927daa62417159d49783041338921dcf646fc7"},
+    {file = "mypy-1.11.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:75746e06d5fa1e91bfd5432448d00d34593b52e7e91a187d981d08d1f33d4385"},
+    {file = "mypy-1.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a976775ab2256aadc6add633d44f100a2517d2388906ec4f13231fafbb0eccca"},
+    {file = "mypy-1.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd953f221ac1379050a8a646585a29574488974f79d8082cedef62744f0a0104"},
+    {file = "mypy-1.11.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:57555a7715c0a34421013144a33d280e73c08df70f3a18a552938587ce9274f4"},
+    {file = "mypy-1.11.2-cp311-cp311-win_amd64.whl", hash = "sha256:36383a4fcbad95f2657642a07ba22ff797de26277158f1cc7bd234821468b1b6"},
+    {file = "mypy-1.11.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e8960dbbbf36906c5c0b7f4fbf2f0c7ffb20f4898e6a879fcf56a41a08b0d318"},
+    {file = "mypy-1.11.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06d26c277962f3fb50e13044674aa10553981ae514288cb7d0a738f495550b36"},
+    {file = "mypy-1.11.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e7184632d89d677973a14d00ae4d03214c8bc301ceefcdaf5c474866814c987"},
+    {file = "mypy-1.11.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3a66169b92452f72117e2da3a576087025449018afc2d8e9bfe5ffab865709ca"},
+    {file = "mypy-1.11.2-cp312-cp312-win_amd64.whl", hash = "sha256:969ea3ef09617aff826885a22ece0ddef69d95852cdad2f60c8bb06bf1f71f70"},
+    {file = "mypy-1.11.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:37c7fa6121c1cdfcaac97ce3d3b5588e847aa79b580c1e922bb5d5d2902df19b"},
+    {file = "mypy-1.11.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a8a53bc3ffbd161b5b2a4fff2f0f1e23a33b0168f1c0778ec70e1a3d66deb86"},
+    {file = "mypy-1.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ff93107f01968ed834f4256bc1fc4475e2fecf6c661260066a985b52741ddce"},
+    {file = "mypy-1.11.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:edb91dded4df17eae4537668b23f0ff6baf3707683734b6a818d5b9d0c0c31a1"},
+    {file = "mypy-1.11.2-cp38-cp38-win_amd64.whl", hash = "sha256:ee23de8530d99b6db0573c4ef4bd8f39a2a6f9b60655bf7a1357e585a3486f2b"},
+    {file = "mypy-1.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:801ca29f43d5acce85f8e999b1e431fb479cb02d0e11deb7d2abb56bdaf24fd6"},
+    {file = "mypy-1.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af8d155170fcf87a2afb55b35dc1a0ac21df4431e7d96717621962e4b9192e70"},
+    {file = "mypy-1.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7821776e5c4286b6a13138cc935e2e9b6fde05e081bdebf5cdb2bb97c9df81d"},
+    {file = "mypy-1.11.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:539c570477a96a4e6fb718b8d5c3e0c0eba1f485df13f86d2970c91f0673148d"},
+    {file = "mypy-1.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:3f14cd3d386ac4d05c5a39a51b84387403dadbd936e17cb35882134d4f8f0d24"},
+    {file = "mypy-1.11.2-py3-none-any.whl", hash = "sha256:b499bc07dbdcd3de92b0a8b29fdf592c111276f6a12fe29c30f6c417dd546d12"},
+    {file = "mypy-1.11.2.tar.gz", hash = "sha256:7f9993ad3e0ffdc95c2a14b66dee63729f021968bff8ad911867579c65d13a79"},
 ]
 
 [package.dependencies]
@@ -870,6 +916,96 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 files = [
     {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
     {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
+]
+
+[[package]]
+name = "ogmios"
+version = "1.1.1"
+description = "Ogmios is a lightweight bridge interface for cardano-node. It offers a WebSockets API that enables local clients to speak Ouroboros' mini-protocols via JSON/RPC. ogmios-python is an Ogmios client written in Python designed for ease of use."
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "ogmios-1.1.1-py3-none-any.whl", hash = "sha256:ff289416452ff78e39c772824c88e90a762f9d16fd893e42a52b22cf533cf344"},
+    {file = "ogmios-1.1.1.tar.gz", hash = "sha256:b24884c2ce497cf72394c03aecb94eec27f14f79b305e5b0816544703fba0c60"},
+]
+
+[package.dependencies]
+cachetools = "*"
+cardano-tools = "*"
+coloredlogs = "*"
+orjson = "*"
+pycardano = "*"
+pydantic = ">=2.0"
+websockets = "*"
+
+[package.extras]
+dev = ["black", "datamodel-code-generator", "flake8-pyproject", "isort", "sphinx", "sphinx-rtd-theme"]
+testing = ["coverage[toml] (>=6.5)", "pytest"]
+
+[[package]]
+name = "orjson"
+version = "3.10.7"
+description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "orjson-3.10.7-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:74f4544f5a6405b90da8ea724d15ac9c36da4d72a738c64685003337401f5c12"},
+    {file = "orjson-3.10.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34a566f22c28222b08875b18b0dfbf8a947e69df21a9ed5c51a6bf91cfb944ac"},
+    {file = "orjson-3.10.7-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf6ba8ebc8ef5792e2337fb0419f8009729335bb400ece005606336b7fd7bab7"},
+    {file = "orjson-3.10.7-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac7cf6222b29fbda9e3a472b41e6a5538b48f2c8f99261eecd60aafbdb60690c"},
+    {file = "orjson-3.10.7-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:de817e2f5fc75a9e7dd350c4b0f54617b280e26d1631811a43e7e968fa71e3e9"},
+    {file = "orjson-3.10.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:348bdd16b32556cf8d7257b17cf2bdb7ab7976af4af41ebe79f9796c218f7e91"},
+    {file = "orjson-3.10.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:479fd0844ddc3ca77e0fd99644c7fe2de8e8be1efcd57705b5c92e5186e8a250"},
+    {file = "orjson-3.10.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:fdf5197a21dd660cf19dfd2a3ce79574588f8f5e2dbf21bda9ee2d2b46924d84"},
+    {file = "orjson-3.10.7-cp310-none-win32.whl", hash = "sha256:d374d36726746c81a49f3ff8daa2898dccab6596864ebe43d50733275c629175"},
+    {file = "orjson-3.10.7-cp310-none-win_amd64.whl", hash = "sha256:cb61938aec8b0ffb6eef484d480188a1777e67b05d58e41b435c74b9d84e0b9c"},
+    {file = "orjson-3.10.7-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:7db8539039698ddfb9a524b4dd19508256107568cdad24f3682d5773e60504a2"},
+    {file = "orjson-3.10.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:480f455222cb7a1dea35c57a67578848537d2602b46c464472c995297117fa09"},
+    {file = "orjson-3.10.7-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8a9c9b168b3a19e37fe2778c0003359f07822c90fdff8f98d9d2a91b3144d8e0"},
+    {file = "orjson-3.10.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8de062de550f63185e4c1c54151bdddfc5625e37daf0aa1e75d2a1293e3b7d9a"},
+    {file = "orjson-3.10.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6b0dd04483499d1de9c8f6203f8975caf17a6000b9c0c54630cef02e44ee624e"},
+    {file = "orjson-3.10.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b58d3795dafa334fc8fd46f7c5dc013e6ad06fd5b9a4cc98cb1456e7d3558bd6"},
+    {file = "orjson-3.10.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:33cfb96c24034a878d83d1a9415799a73dc77480e6c40417e5dda0710d559ee6"},
+    {file = "orjson-3.10.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e724cebe1fadc2b23c6f7415bad5ee6239e00a69f30ee423f319c6af70e2a5c0"},
+    {file = "orjson-3.10.7-cp311-none-win32.whl", hash = "sha256:82763b46053727a7168d29c772ed5c870fdae2f61aa8a25994c7984a19b1021f"},
+    {file = "orjson-3.10.7-cp311-none-win_amd64.whl", hash = "sha256:eb8d384a24778abf29afb8e41d68fdd9a156cf6e5390c04cc07bbc24b89e98b5"},
+    {file = "orjson-3.10.7-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:44a96f2d4c3af51bfac6bc4ef7b182aa33f2f054fd7f34cc0ee9a320d051d41f"},
+    {file = "orjson-3.10.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76ac14cd57df0572453543f8f2575e2d01ae9e790c21f57627803f5e79b0d3c3"},
+    {file = "orjson-3.10.7-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bdbb61dcc365dd9be94e8f7df91975edc9364d6a78c8f7adb69c1cdff318ec93"},
+    {file = "orjson-3.10.7-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b48b3db6bb6e0a08fa8c83b47bc169623f801e5cc4f24442ab2b6617da3b5313"},
+    {file = "orjson-3.10.7-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:23820a1563a1d386414fef15c249040042b8e5d07b40ab3fe3efbfbbcbcb8864"},
+    {file = "orjson-3.10.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0c6a008e91d10a2564edbb6ee5069a9e66df3fbe11c9a005cb411f441fd2c09"},
+    {file = "orjson-3.10.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d352ee8ac1926d6193f602cbe36b1643bbd1bbcb25e3c1a657a4390f3000c9a5"},
+    {file = "orjson-3.10.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d2d9f990623f15c0ae7ac608103c33dfe1486d2ed974ac3f40b693bad1a22a7b"},
+    {file = "orjson-3.10.7-cp312-none-win32.whl", hash = "sha256:7c4c17f8157bd520cdb7195f75ddbd31671997cbe10aee559c2d613592e7d7eb"},
+    {file = "orjson-3.10.7-cp312-none-win_amd64.whl", hash = "sha256:1d9c0e733e02ada3ed6098a10a8ee0052dd55774de3d9110d29868d24b17faa1"},
+    {file = "orjson-3.10.7-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:77d325ed866876c0fa6492598ec01fe30e803272a6e8b10e992288b009cbe149"},
+    {file = "orjson-3.10.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ea2c232deedcb605e853ae1db2cc94f7390ac776743b699b50b071b02bea6fe"},
+    {file = "orjson-3.10.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3dcfbede6737fdbef3ce9c37af3fb6142e8e1ebc10336daa05872bfb1d87839c"},
+    {file = "orjson-3.10.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:11748c135f281203f4ee695b7f80bb1358a82a63905f9f0b794769483ea854ad"},
+    {file = "orjson-3.10.7-cp313-none-win32.whl", hash = "sha256:a7e19150d215c7a13f39eb787d84db274298d3f83d85463e61d277bbd7f401d2"},
+    {file = "orjson-3.10.7-cp313-none-win_amd64.whl", hash = "sha256:eef44224729e9525d5261cc8d28d6b11cafc90e6bd0be2157bde69a52ec83024"},
+    {file = "orjson-3.10.7-cp38-cp38-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:6ea2b2258eff652c82652d5e0f02bd5e0463a6a52abb78e49ac288827aaa1469"},
+    {file = "orjson-3.10.7-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:430ee4d85841e1483d487e7b81401785a5dfd69db5de01314538f31f8fbf7ee1"},
+    {file = "orjson-3.10.7-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4b6146e439af4c2472c56f8540d799a67a81226e11992008cb47e1267a9b3225"},
+    {file = "orjson-3.10.7-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:084e537806b458911137f76097e53ce7bf5806dda33ddf6aaa66a028f8d43a23"},
+    {file = "orjson-3.10.7-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4829cf2195838e3f93b70fd3b4292156fc5e097aac3739859ac0dcc722b27ac0"},
+    {file = "orjson-3.10.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1193b2416cbad1a769f868b1749535d5da47626ac29445803dae7cc64b3f5c98"},
+    {file = "orjson-3.10.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:4e6c3da13e5a57e4b3dca2de059f243ebec705857522f188f0180ae88badd354"},
+    {file = "orjson-3.10.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:c31008598424dfbe52ce8c5b47e0752dca918a4fdc4a2a32004efd9fab41d866"},
+    {file = "orjson-3.10.7-cp38-none-win32.whl", hash = "sha256:7122a99831f9e7fe977dc45784d3b2edc821c172d545e6420c375e5a935f5a1c"},
+    {file = "orjson-3.10.7-cp38-none-win_amd64.whl", hash = "sha256:a763bc0e58504cc803739e7df040685816145a6f3c8a589787084b54ebc9f16e"},
+    {file = "orjson-3.10.7-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:e76be12658a6fa376fcd331b1ea4e58f5a06fd0220653450f0d415b8fd0fbe20"},
+    {file = "orjson-3.10.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed350d6978d28b92939bfeb1a0570c523f6170efc3f0a0ef1f1df287cd4f4960"},
+    {file = "orjson-3.10.7-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:144888c76f8520e39bfa121b31fd637e18d4cc2f115727865fdf9fa325b10412"},
+    {file = "orjson-3.10.7-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09b2d92fd95ad2402188cf51573acde57eb269eddabaa60f69ea0d733e789fe9"},
+    {file = "orjson-3.10.7-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5b24a579123fa884f3a3caadaed7b75eb5715ee2b17ab5c66ac97d29b18fe57f"},
+    {file = "orjson-3.10.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72591bcfe7512353bd609875ab38050efe3d55e18934e2f18950c108334b4ff"},
+    {file = "orjson-3.10.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f4db56635b58cd1a200b0a23744ff44206ee6aa428185e2b6c4a65b3197abdcd"},
+    {file = "orjson-3.10.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0fa5886854673222618638c6df7718ea7fe2f3f2384c452c9ccedc70b4a510a5"},
+    {file = "orjson-3.10.7-cp39-none-win32.whl", hash = "sha256:8272527d08450ab16eb405f47e0f4ef0e5ff5981c3d82afe0efd25dcbef2bcd2"},
+    {file = "orjson-3.10.7-cp39-none-win_amd64.whl", hash = "sha256:974683d4618c0c7dbf4f69c95a979734bf183d0658611760017f6e70a145af58"},
+    {file = "orjson-3.10.7.tar.gz", hash = "sha256:75ef0640403f945f3a1f9f6400686560dbfb0fb5b16589ad62cd477043c4eee3"},
 ]
 
 [[package]]
@@ -907,6 +1043,20 @@ files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
     {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+description = "Pexpect allows easy control of interactive console applications."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
+    {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
+]
+
+[package.dependencies]
+ptyprocess = ">=0.5"
 
 [[package]]
 name = "platformdirs"
@@ -1068,6 +1218,17 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.4"
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
+]
 
 [[package]]
 name = "py-cpuinfo"
@@ -1287,6 +1448,17 @@ cffi = ">=1.4.1"
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
 tests = ["hypothesis (>=3.27.0)", "pytest (>=3.2.1,!=3.3.0)"]
+
+[[package]]
+name = "pyreadline3"
+version = "3.4.1"
+description = "A python implementation of GNU readline."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pyreadline3-3.4.1-py3-none-any.whl", hash = "sha256:b0efb6516fd4fb07b45949053826a62fa4cb353db5be2bbb4a7aa1fdd1e345fb"},
+    {file = "pyreadline3-3.4.1.tar.gz", hash = "sha256:6f3d1f7b8a31ba32b73917cefc1f28cc660562f39aea8646d30bd6eff21f7bae"},
+]
 
 [[package]]
 name = "pytest"
@@ -1639,7 +1811,102 @@ docs = ["Sphinx (>=6.0)", "myst-parser (>=2.0.0)", "sphinx-rtd-theme (>=1.1.0)"]
 optional = ["python-socks", "wsaccel"]
 test = ["websockets"]
 
+[[package]]
+name = "websockets"
+version = "13.0.1"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "websockets-13.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1841c9082a3ba4a05ea824cf6d99570a6a2d8849ef0db16e9c826acb28089e8f"},
+    {file = "websockets-13.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c5870b4a11b77e4caa3937142b650fbbc0914a3e07a0cf3131f35c0587489c1c"},
+    {file = "websockets-13.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f1d3d1f2eb79fe7b0fb02e599b2bf76a7619c79300fc55f0b5e2d382881d4f7f"},
+    {file = "websockets-13.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15c7d62ee071fa94a2fc52c2b472fed4af258d43f9030479d9c4a2de885fd543"},
+    {file = "websockets-13.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6724b554b70d6195ba19650fef5759ef11346f946c07dbbe390e039bcaa7cc3d"},
+    {file = "websockets-13.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56a952fa2ae57a42ba7951e6b2605e08a24801a4931b5644dfc68939e041bc7f"},
+    {file = "websockets-13.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:17118647c0ea14796364299e942c330d72acc4b248e07e639d34b75067b3cdd8"},
+    {file = "websockets-13.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:64a11aae1de4c178fa653b07d90f2fb1a2ed31919a5ea2361a38760192e1858b"},
+    {file = "websockets-13.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0617fd0b1d14309c7eab6ba5deae8a7179959861846cbc5cb528a7531c249448"},
+    {file = "websockets-13.0.1-cp310-cp310-win32.whl", hash = "sha256:11f9976ecbc530248cf162e359a92f37b7b282de88d1d194f2167b5e7ad80ce3"},
+    {file = "websockets-13.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:c3c493d0e5141ec055a7d6809a28ac2b88d5b878bb22df8c621ebe79a61123d0"},
+    {file = "websockets-13.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:699ba9dd6a926f82a277063603fc8d586b89f4cb128efc353b749b641fcddda7"},
+    {file = "websockets-13.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cf2fae6d85e5dc384bf846f8243ddaa9197f3a1a70044f59399af001fd1f51d4"},
+    {file = "websockets-13.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:52aed6ef21a0f1a2a5e310fb5c42d7555e9c5855476bbd7173c3aa3d8a0302f2"},
+    {file = "websockets-13.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8eb2b9a318542153674c6e377eb8cb9ca0fc011c04475110d3477862f15d29f0"},
+    {file = "websockets-13.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5df891c86fe68b2c38da55b7aea7095beca105933c697d719f3f45f4220a5e0e"},
+    {file = "websockets-13.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fac2d146ff30d9dd2fcf917e5d147db037a5c573f0446c564f16f1f94cf87462"},
+    {file = "websockets-13.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b8ac5b46fd798bbbf2ac6620e0437c36a202b08e1f827832c4bf050da081b501"},
+    {file = "websockets-13.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:46af561eba6f9b0848b2c9d2427086cabadf14e0abdd9fde9d72d447df268418"},
+    {file = "websockets-13.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b5a06d7f60bc2fc378a333978470dfc4e1415ee52f5f0fce4f7853eb10c1e9df"},
+    {file = "websockets-13.0.1-cp311-cp311-win32.whl", hash = "sha256:556e70e4f69be1082e6ef26dcb70efcd08d1850f5d6c5f4f2bcb4e397e68f01f"},
+    {file = "websockets-13.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:67494e95d6565bf395476e9d040037ff69c8b3fa356a886b21d8422ad86ae075"},
+    {file = "websockets-13.0.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f9c9e258e3d5efe199ec23903f5da0eeaad58cf6fccb3547b74fd4750e5ac47a"},
+    {file = "websockets-13.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6b41a1b3b561f1cba8321fb32987552a024a8f67f0d05f06fcf29f0090a1b956"},
+    {file = "websockets-13.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f73e676a46b0fe9426612ce8caeca54c9073191a77c3e9d5c94697aef99296af"},
+    {file = "websockets-13.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f613289f4a94142f914aafad6c6c87903de78eae1e140fa769a7385fb232fdf"},
+    {file = "websockets-13.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0f52504023b1480d458adf496dc1c9e9811df4ba4752f0bc1f89ae92f4f07d0c"},
+    {file = "websockets-13.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:139add0f98206cb74109faf3611b7783ceafc928529c62b389917a037d4cfdf4"},
+    {file = "websockets-13.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:47236c13be337ef36546004ce8c5580f4b1150d9538b27bf8a5ad8edf23ccfab"},
+    {file = "websockets-13.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c44ca9ade59b2e376612df34e837013e2b273e6c92d7ed6636d0556b6f4db93d"},
+    {file = "websockets-13.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9bbc525f4be3e51b89b2a700f5746c2a6907d2e2ef4513a8daafc98198b92237"},
+    {file = "websockets-13.0.1-cp312-cp312-win32.whl", hash = "sha256:3624fd8664f2577cf8de996db3250662e259bfbc870dd8ebdcf5d7c6ac0b5185"},
+    {file = "websockets-13.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0513c727fb8adffa6d9bf4a4463b2bade0186cbd8c3604ae5540fae18a90cb99"},
+    {file = "websockets-13.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1ee4cc030a4bdab482a37462dbf3ffb7e09334d01dd37d1063be1136a0d825fa"},
+    {file = "websockets-13.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:dbb0b697cc0655719522406c059eae233abaa3243821cfdfab1215d02ac10231"},
+    {file = "websockets-13.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:acbebec8cb3d4df6e2488fbf34702cbc37fc39ac7abf9449392cefb3305562e9"},
+    {file = "websockets-13.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63848cdb6fcc0bf09d4a155464c46c64ffdb5807ede4fb251da2c2692559ce75"},
+    {file = "websockets-13.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:872afa52a9f4c414d6955c365b6588bc4401272c629ff8321a55f44e3f62b553"},
+    {file = "websockets-13.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05e70fec7c54aad4d71eae8e8cab50525e899791fc389ec6f77b95312e4e9920"},
+    {file = "websockets-13.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e82db3756ccb66266504f5a3de05ac6b32f287faacff72462612120074103329"},
+    {file = "websockets-13.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4e85f46ce287f5c52438bb3703d86162263afccf034a5ef13dbe4318e98d86e7"},
+    {file = "websockets-13.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f3fea72e4e6edb983908f0db373ae0732b275628901d909c382aae3b592589f2"},
+    {file = "websockets-13.0.1-cp313-cp313-win32.whl", hash = "sha256:254ecf35572fca01a9f789a1d0f543898e222f7b69ecd7d5381d8d8047627bdb"},
+    {file = "websockets-13.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:ca48914cdd9f2ccd94deab5bcb5ac98025a5ddce98881e5cce762854a5de330b"},
+    {file = "websockets-13.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:b74593e9acf18ea5469c3edaa6b27fa7ecf97b30e9dabd5a94c4c940637ab96e"},
+    {file = "websockets-13.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:132511bfd42e77d152c919147078460c88a795af16b50e42a0bd14f0ad71ddd2"},
+    {file = "websockets-13.0.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:165bedf13556f985a2aa064309baa01462aa79bf6112fbd068ae38993a0e1f1b"},
+    {file = "websockets-13.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e801ca2f448850685417d723ec70298feff3ce4ff687c6f20922c7474b4746ae"},
+    {file = "websockets-13.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30d3a1f041360f029765d8704eae606781e673e8918e6b2c792e0775de51352f"},
+    {file = "websockets-13.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67648f5e50231b5a7f6d83b32f9c525e319f0ddc841be0de64f24928cd75a603"},
+    {file = "websockets-13.0.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:4f0426d51c8f0926a4879390f53c7f5a855e42d68df95fff6032c82c888b5f36"},
+    {file = "websockets-13.0.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:ef48e4137e8799998a343706531e656fdec6797b80efd029117edacb74b0a10a"},
+    {file = "websockets-13.0.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:249aab278810bee585cd0d4de2f08cfd67eed4fc75bde623be163798ed4db2eb"},
+    {file = "websockets-13.0.1-cp38-cp38-win32.whl", hash = "sha256:06c0a667e466fcb56a0886d924b5f29a7f0886199102f0a0e1c60a02a3751cb4"},
+    {file = "websockets-13.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1f3cf6d6ec1142412d4535adabc6bd72a63f5f148c43fe559f06298bc21953c9"},
+    {file = "websockets-13.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1fa082ea38d5de51dd409434edc27c0dcbd5fed2b09b9be982deb6f0508d25bc"},
+    {file = "websockets-13.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4a365bcb7be554e6e1f9f3ed64016e67e2fa03d7b027a33e436aecf194febb63"},
+    {file = "websockets-13.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:10a0dc7242215d794fb1918f69c6bb235f1f627aaf19e77f05336d147fce7c37"},
+    {file = "websockets-13.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59197afd478545b1f73367620407b0083303569c5f2d043afe5363676f2697c9"},
+    {file = "websockets-13.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d20516990d8ad557b5abeb48127b8b779b0b7e6771a265fa3e91767596d7d97"},
+    {file = "websockets-13.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1a2e272d067030048e1fe41aa1ec8cfbbaabce733b3d634304fa2b19e5c897f"},
+    {file = "websockets-13.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ad327ac80ba7ee61da85383ca8822ff808ab5ada0e4a030d66703cc025b021c4"},
+    {file = "websockets-13.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:518f90e6dd089d34eaade01101fd8a990921c3ba18ebbe9b0165b46ebff947f0"},
+    {file = "websockets-13.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:68264802399aed6fe9652e89761031acc734fc4c653137a5911c2bfa995d6d6d"},
+    {file = "websockets-13.0.1-cp39-cp39-win32.whl", hash = "sha256:a5dc0c42ded1557cc7c3f0240b24129aefbad88af4f09346164349391dea8e58"},
+    {file = "websockets-13.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b448a0690ef43db5ef31b3a0d9aea79043882b4632cfc3eaab20105edecf6097"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:faef9ec6354fe4f9a2c0bbb52fb1ff852effc897e2a4501e25eb3a47cb0a4f89"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:03d3f9ba172e0a53e37fa4e636b86cc60c3ab2cfee4935e66ed1d7acaa4625ad"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d450f5a7a35662a9b91a64aefa852f0c0308ee256122f5218a42f1d13577d71e"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f55b36d17ac50aa8a171b771e15fbe1561217510c8768af3d546f56c7576cdc"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14b9c006cac63772b31abbcd3e3abb6228233eec966bf062e89e7fa7ae0b7333"},
+    {file = "websockets-13.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b79915a1179a91f6c5f04ece1e592e2e8a6bd245a0e45d12fd56b2b59e559a32"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f40de079779acbcdbb6ed4c65af9f018f8b77c5ec4e17a4b737c05c2db554491"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:80e4ba642fc87fa532bac07e5ed7e19d56940b6af6a8c61d4429be48718a380f"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a02b0161c43cc9e0232711eff846569fad6ec836a7acab16b3cf97b2344c060"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6aa74a45d4cdc028561a7d6ab3272c8b3018e23723100b12e58be9dfa5a24491"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00fd961943b6c10ee6f0b1130753e50ac5dcd906130dcd77b0003c3ab797d026"},
+    {file = "websockets-13.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:d93572720d781331fb10d3da9ca1067817d84ad1e7c31466e9f5e59965618096"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:71e6e5a3a3728886caee9ab8752e8113670936a193284be9d6ad2176a137f376"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:c4a6343e3b0714e80da0b0893543bf9a5b5fa71b846ae640e56e9abc6fbc4c83"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a678532018e435396e37422a95e3ab87f75028ac79570ad11f5bf23cd2a7d8c"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d6716c087e4aa0b9260c4e579bb82e068f84faddb9bfba9906cb87726fa2e870"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e33505534f3f673270dd67f81e73550b11de5b538c56fe04435d63c02c3f26b5"},
+    {file = "websockets-13.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:acab3539a027a85d568c2573291e864333ec9d912675107d6efceb7e2be5d980"},
+    {file = "websockets-13.0.1-py3-none-any.whl", hash = "sha256:b80f0c51681c517604152eb6a572f5a9378f877763231fddb883ba2f968e8817"},
+    {file = "websockets-13.0.1.tar.gz", hash = "sha256:4d6ece65099411cfd9a48d13701d7438d9c34f479046b34c50ff60bb8834e43e"},
+]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e81fa19d69925a711349bd0afdb079d910a62c29f6b62dd7b1b6a6e827fca32b"
+content-hash = "79e39bd0e6be3e9e2a013f5c0ed23fdff66b83cb6c755babffc16a9b6ca567e4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ psycopg = {extras = ["binary", "pool"], version = "^3.1.13"}
 python-dotenv = "0.21.1"
 pycardano = "0.11.1"
 blockfrost-python = "^0.5.3"
+ogmios = "^1.1.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/charli3_dendrite/backend/__init__.py
+++ b/src/charli3_dendrite/backend/__init__.py
@@ -1,8 +1,8 @@
 """Backend Management Module for Charli3 Dendrite.
 
 This module provides a centralized system for managing the backend used throughout
-the Charli3 Dendrite application. It includes functions to get and set the global backend,
-as well as to set a default backend based on environment variables.
+the Charli3 Dendrite application. It includes functions to get and set the global
+backend, as well as to set a default backend based on environment variables.
 
 The module uses a global variable to store the current backend instance, which
 can be accessed and modified using the provided functions. This approach allows
@@ -27,8 +27,8 @@ import logging
 import os
 from typing import Optional
 
-from dotenv import load_dotenv
-from pycardano import Network
+from dotenv import load_dotenv  # type: ignore
+from pycardano import Network  # type: ignore
 
 from charli3_dendrite.backend.backend_base import AbstractBackend
 from charli3_dendrite.backend.blockfrost import BlockFrostBackend

--- a/src/charli3_dendrite/backend/__init__.py
+++ b/src/charli3_dendrite/backend/__init__.py
@@ -95,7 +95,7 @@ def set_default_backend() -> None:
         set_backend(
             BlockFrostBackend(
                 project_id=os.environ["BLOCKFROST_PROJECT_ID"],
-            )
+            ),
         )
         return
 
@@ -116,7 +116,7 @@ def set_default_backend() -> None:
                 ogmios_url=os.environ["OGMIOS_URL"],
                 kupo_url=os.environ["KUPO_URL"],
                 network=network,
-            )
+            ),
         )
         return
 

--- a/src/charli3_dendrite/backend/__init__.py
+++ b/src/charli3_dendrite/backend/__init__.py
@@ -23,13 +23,17 @@ Note: This module relies on environment variables for setting up the default bac
 Ensure that the necessary environment variables are set before using this module.
 """
 
+import logging
 import os
 from typing import Optional
 
 from dotenv import load_dotenv
+from pycardano import Network
 
 from charli3_dendrite.backend.backend_base import AbstractBackend
+from charli3_dendrite.backend.blockfrost import BlockFrostBackend
 from charli3_dendrite.backend.dbsync import DbsyncBackend
+from charli3_dendrite.backend.ogmios_kupo import OgmiosKupoBackend
 
 # Load environment variables from .env file
 load_dotenv()
@@ -71,9 +75,8 @@ def set_default_backend() -> None:
     """Attempt to set a default backend based on environment variables.
 
     This function checks for the presence of specific environment variables
-    to determine which backend to use as the default. Currently, it only
-    checks for DBSync-related variables, but can be extended to support
-    other backend types in the future.
+    to determine which backend to use as the default. It checks for DBSync-related
+    variables first, then for Blockfrost, and finally for Ogmios and Kupo variables.
     """
     # Check for DBSync environment variables
     dbsync_vars = [
@@ -85,13 +88,41 @@ def set_default_backend() -> None:
     ]
     if all(env_var in os.environ for env_var in dbsync_vars):
         set_backend(DbsyncBackend())
+        return
 
-    """ TODO: Add checks for other backend types here as needed
-    For example:
-    elif all(env_var in os.environ for env_var in other_backend_vars):
-        set_backend(OtherBackend())
-    """
+    # Check for Blockfrost environment variables
+    if "BLOCKFROST_PROJECT_ID" in os.environ:
+        set_backend(
+            BlockFrostBackend(
+                project_id=os.environ["BLOCKFROST_PROJECT_ID"],
+            )
+        )
+        return
+
+    # Check for Ogmios and Kupo environment variables
+    ogmios_kupo_vars = [
+        "OGMIOS_URL",
+        "KUPO_URL",
+        "CARDANO_NETWORK",
+    ]
+    if all(env_var in os.environ for env_var in ogmios_kupo_vars):
+        network = (
+            Network.MAINNET
+            if os.environ["CARDANO_NETWORK"].upper() == "MAINNET"
+            else Network.TESTNET
+        )
+        set_backend(
+            OgmiosKupoBackend(
+                ogmios_url=os.environ["OGMIOS_URL"],
+                kupo_url=os.environ["KUPO_URL"],
+                network=network,
+            )
+        )
+        return
+
+    # If no backend can be set, log a warning
+    logging.warning("No default backend could be set. Please set a backend manually.")
 
 
-# Optional: Initialize the backend when the module is imported
+# Initialize the backend when the module is imported
 set_default_backend()

--- a/src/charli3_dendrite/backend/blockfrost.py
+++ b/src/charli3_dendrite/backend/blockfrost.py
@@ -29,7 +29,8 @@ class BlockFrostBackend(AbstractBackend):
             project_id (str): The BlockFrost project ID.
         """
         self.chain_context = BlockFrostChainContext(
-            project_id, base_url=ApiUrls.mainnet.value,
+            project_id,
+            base_url=ApiUrls.mainnet.value,
         )
         self.api = self.chain_context.api
         self._block_cache: dict = {}
@@ -246,7 +247,9 @@ class BlockFrostBackend(AbstractBackend):
         )
 
     def get_datum_from_address(
-        self, address: str, asset: Optional[str] = None,
+        self,
+        address: str,
+        asset: Optional[str] = None,
     ) -> Optional[ScriptReference]:
         """Get datum from a given address.
 

--- a/src/charli3_dendrite/backend/blockfrost.py
+++ b/src/charli3_dendrite/backend/blockfrost.py
@@ -1,21 +1,22 @@
 """BlockFrostBackend class for interacting with the BlockFrost API."""
 
-from typing import List, Optional, Union
 import functools
 from datetime import datetime
+from typing import List
+from typing import Optional
+from typing import Union
 
-from pycardano import Address, BlockFrostChainContext
 from blockfrost import ApiUrls
+from pycardano import Address
+from pycardano import BlockFrostChainContext
 
 from charli3_dendrite.backend.backend_base import AbstractBackend
-from charli3_dendrite.dataclasses.models import (
-    Assets,
-    BlockList,
-    PoolStateInfo,
-    PoolStateList,
-    ScriptReference,
-    SwapTransactionList,
-)
+from charli3_dendrite.dataclasses.models import Assets
+from charli3_dendrite.dataclasses.models import BlockList
+from charli3_dendrite.dataclasses.models import PoolStateInfo
+from charli3_dendrite.dataclasses.models import PoolStateList
+from charli3_dendrite.dataclasses.models import ScriptReference
+from charli3_dendrite.dataclasses.models import SwapTransactionList
 
 
 class BlockFrostBackend(AbstractBackend):
@@ -28,7 +29,7 @@ class BlockFrostBackend(AbstractBackend):
             project_id (str): The BlockFrost project ID.
         """
         self.chain_context = BlockFrostChainContext(
-            project_id, base_url=ApiUrls.mainnet.value
+            project_id, base_url=ApiUrls.mainnet.value,
         )
         self.api = self.chain_context.api
         self._block_cache: dict = {}
@@ -80,7 +81,7 @@ class BlockFrostBackend(AbstractBackend):
                 utxos = []
                 for asset in assets:
                     utxos.extend(
-                        self.api.address_utxos_asset(address, asset, gather_pages=True)
+                        self.api.address_utxos_asset(address, asset, gather_pages=True),
                     )
             else:
                 utxos = self.api.address_utxos(address, gather_pages=True)
@@ -143,7 +144,7 @@ class BlockFrostBackend(AbstractBackend):
                     "block_no": block.height,
                     "tx_count": block.tx_count,
                     "block_time": block.time,
-                }
+                },
             )
         return BlockList(root=blocks)
 
@@ -201,7 +202,7 @@ class BlockFrostBackend(AbstractBackend):
             NotImplementedError: This method is not implemented.
         """
         raise NotImplementedError(
-            "This method is not supported due to limited data availability"
+            "This method is not supported due to limited data availability",
         )
 
     def get_order_utxos_by_block_or_tx(
@@ -222,7 +223,7 @@ class BlockFrostBackend(AbstractBackend):
             NotImplementedError: This method is not implemented.
         """
         raise NotImplementedError(
-            "This method is not supported due to limited data availability"
+            "This method is not supported due to limited data availability",
         )
 
     def get_cancel_utxos(
@@ -241,11 +242,11 @@ class BlockFrostBackend(AbstractBackend):
             NotImplementedError: This method is not implemented.
         """
         raise NotImplementedError(
-            "This method is not supported due to limited data availability"
+            "This method is not supported due to limited data availability",
         )
 
     def get_datum_from_address(
-        self, address: str, asset: Optional[str] = None
+        self, address: str, asset: Optional[str] = None,
     ) -> Optional[ScriptReference]:
         """Get datum from a given address.
 
@@ -289,7 +290,7 @@ class BlockFrostBackend(AbstractBackend):
             NotImplementedError: This method is not implemented.
         """
         raise NotImplementedError(
-            "This method is not supported due to limited data availability"
+            "This method is not supported due to limited data availability",
         )
 
     def _utxo_to_pool_state(self, utxo, tx_hash: Optional[str] = None) -> PoolStateInfo:

--- a/src/charli3_dendrite/backend/blockfrost.py
+++ b/src/charli3_dendrite/backend/blockfrost.py
@@ -1,0 +1,377 @@
+"""BlockFrostBackend class for interacting with the BlockFrost API."""
+
+from typing import List, Optional, Union
+import functools
+from datetime import datetime
+
+from pycardano import Address, BlockFrostChainContext
+from blockfrost import ApiUrls
+
+from charli3_dendrite.backend.backend_base import AbstractBackend
+from charli3_dendrite.dataclasses.models import (
+    Assets,
+    BlockList,
+    PoolStateInfo,
+    PoolStateList,
+    ScriptReference,
+    SwapTransactionList,
+)
+
+
+class BlockFrostBackend(AbstractBackend):
+    """BlockFrostBackend class for interacting with the BlockFrost API."""
+
+    def __init__(self, project_id: str) -> None:
+        """Initialize the BlockFrostBackend.
+
+        Args:
+            project_id (str): The BlockFrost project ID.
+        """
+        self.chain_context = BlockFrostChainContext(
+            project_id, base_url=ApiUrls.mainnet.value
+        )
+        self.api = self.chain_context.api
+        self._block_cache: dict = {}
+
+    @functools.lru_cache(maxsize=100)
+    def _get_block_info(self, block_hash: str) -> dict:
+        """Get block information from cache or API.
+
+        Args:
+            block_hash (str): The hash of the block.
+
+        Returns:
+            dict: Block information.
+        """
+        if block_hash not in self._block_cache:
+            block_info = self.api.block(block_hash)
+            self._block_cache[block_hash] = {
+                "time": block_info.time,
+                "height": block_info.height,
+            }
+        return self._block_cache[block_hash]
+
+    def get_pool_utxos(
+        self,
+        assets: Optional[List[str]] = None,
+        addresses: Optional[List[str]] = None,
+        limit: int = 1000,
+        page: int = 100,
+        historical: bool = True,
+    ) -> PoolStateList:
+        """Get pool UTXOs based on assets and addresses.
+
+        Args:
+            assets (Optional[List[str]]): List of asset IDs.
+            addresses (Optional[List[str]]): List of addresses.
+            limit (int): Maximum number of UTXOs to return.
+            page (int): Page number for pagination.
+            historical (bool): Include historical data.
+
+        Returns:
+            PoolStateList: List of pool states.
+        """
+        pool_states = []
+        if addresses is None:
+            return PoolStateList(root=[])
+
+        for address in addresses:
+            if assets:
+                utxos = []
+                for asset in assets:
+                    utxos.extend(
+                        self.api.address_utxos_asset(address, asset, gather_pages=True)
+                    )
+            else:
+                utxos = self.api.address_utxos(address, gather_pages=True)
+
+            for utxo in utxos[:limit]:
+                if utxo.data_hash:
+                    pool_state = self._utxo_to_pool_state(utxo)
+                    if assets:
+                        if any(asset in pool_state.assets for asset in assets):
+                            pool_states.append(pool_state)
+                    else:
+                        pool_states.append(pool_state)
+        return PoolStateList(root=pool_states)
+
+    def get_pool_in_tx(
+        self,
+        tx_hash: str,
+        assets: Optional[List[str]] = None,
+        addresses: Optional[List[str]] = None,
+    ) -> PoolStateList:
+        """Get pool states for a specific transaction.
+
+        Args:
+            tx_hash (str): Transaction hash.
+            assets (Optional[List[str]]): List of asset IDs.
+            addresses (Optional[List[str]]): List of addresses.
+
+        Returns:
+            PoolStateList: List of pool states.
+        """
+        pool_states = []
+        tx_utxos = self.api.transaction_utxos(tx_hash)
+        for utxo in tx_utxos.outputs:
+            if addresses and utxo.address not in addresses:
+                continue
+            pool_state = self._utxo_to_pool_state(utxo, tx_hash)
+            if assets:
+                if any(asset in pool_state.assets for asset in assets):
+                    pool_states.append(pool_state)
+            else:
+                pool_states.append(pool_state)
+        return PoolStateList(root=pool_states)
+
+    def last_block(self, last_n_blocks: int = 2) -> BlockList:
+        """Get information about the last N blocks.
+
+        Args:
+            last_n_blocks (int): Number of recent blocks to retrieve.
+
+        Returns:
+            BlockList: List of recent block information.
+        """
+        blocks = []
+        latest_block = self.api.block_latest()
+        for i in range(last_n_blocks):
+            block = self.api.block(latest_block.height - i)
+            blocks.append(
+                {
+                    "epoch_slot_no": block.epoch_slot,
+                    "block_no": block.height,
+                    "tx_count": block.tx_count,
+                    "block_time": block.time,
+                }
+            )
+        return BlockList(root=blocks)
+
+    def get_pool_utxos_in_block(self, block_no: int) -> PoolStateList:
+        """Get pool UTXOs for a specific block.
+
+        Args:
+            block_no (int): Block number.
+
+        Returns:
+            PoolStateList: List of pool states.
+        """
+        tx_hashes = self.api.block_transactions(block_no)
+        pool_states = []
+        for tx_hash in tx_hashes:
+            tx_utxos = self.api.transaction_utxos(tx_hash)
+            for utxo in tx_utxos.outputs:
+                if utxo.data_hash:  # Only consider UTXOs with datums
+                    pool_states.append(self._utxo_to_pool_state(utxo, tx_hash))
+        return PoolStateList(root=pool_states)
+
+    def get_script_from_address(self, address: Address) -> ScriptReference:
+        """Get script reference for a given address.
+
+        Args:
+            address (Address): The address to query.
+
+        Returns:
+            ScriptReference: Script reference for the address.
+        """
+        script_hash = address.payment_part.payload.hex()
+        script = self.api.script_cbor(script_hash)
+        return ScriptReference(
+            tx_hash=None,
+            tx_index=None,
+            address=str(address),
+            assets=None,
+            datum_hash=None,
+            datum_cbor=None,
+            script=script.cbor,
+        )
+
+    def get_historical_order_utxos(
+        self,
+        stake_addresses: List[str],
+        after_time: Optional[Union[datetime, int]] = None,
+        limit: int = 1000,
+        page: int = 0,
+    ) -> SwapTransactionList:
+        """Get historical order UTXOs.
+
+        This method is not supported due to limited data availability.
+
+        Raises:
+            NotImplementedError: This method is not implemented.
+        """
+        raise NotImplementedError(
+            "This method is not supported due to limited data availability"
+        )
+
+    def get_order_utxos_by_block_or_tx(
+        self,
+        stake_addresses: List[str],
+        out_tx_hash: Optional[List[str]] = None,
+        in_tx_hash: Optional[List[str]] = None,
+        block_no: Optional[int] = None,
+        after_block: Optional[int] = None,
+        limit: int = 1000,
+        page: int = 0,
+    ) -> SwapTransactionList:
+        """Get order UTXOs by block or transaction.
+
+        This method is not supported due to limited data availability.
+
+        Raises:
+            NotImplementedError: This method is not implemented.
+        """
+        raise NotImplementedError(
+            "This method is not supported due to limited data availability"
+        )
+
+    def get_cancel_utxos(
+        self,
+        stake_addresses: List[str],
+        block_no: Optional[int] = None,
+        after_time: Optional[Union[datetime, int]] = None,
+        limit: int = 1000,
+        page: int = 0,
+    ) -> SwapTransactionList:
+        """Get cancelled order UTXOs.
+
+        This method is not supported due to limited data availability.
+
+        Raises:
+            NotImplementedError: This method is not implemented.
+        """
+        raise NotImplementedError(
+            "This method is not supported due to limited data availability"
+        )
+
+    def get_datum_from_address(
+        self, address: str, asset: Optional[str] = None
+    ) -> Optional[ScriptReference]:
+        """Get datum from a given address.
+
+        Args:
+            address (str): The address to query.
+            asset (Optional[str]): Asset to filter by.
+
+        Returns:
+            Optional[ScriptReference]: The datum associated with the address, if any.
+        """
+        utxos = self.api.address_utxos(address, gather_pages=True)
+        for utxo in utxos:
+            if asset and asset not in utxo.amount:
+                continue
+            if utxo.data_hash:
+                return ScriptReference(
+                    tx_hash=utxo.tx_hash,
+                    tx_index=utxo.output_index,
+                    address=utxo.address,
+                    assets=self._format_assets(utxo.amount),
+                    datum_hash=utxo.data_hash,
+                    datum_cbor=(
+                        utxo.inline_datum
+                        if utxo.inline_datum
+                        else self._get_datum_from_datum_hash(utxo.data_hash)
+                    ),
+                    script=None,
+                )
+        return None
+
+    def get_axo_target(
+        self,
+        assets: Assets,
+        block_time: Optional[datetime] = None,
+    ) -> Optional[str]:
+        """Get the target address for the given asset.
+
+        This method is not supported due to limited data availability.
+
+        Raises:
+            NotImplementedError: This method is not implemented.
+        """
+        raise NotImplementedError(
+            "This method is not supported due to limited data availability"
+        )
+
+    def _utxo_to_pool_state(self, utxo, tx_hash: Optional[str] = None) -> PoolStateInfo:
+        """Convert UTXO to PoolStateInfo.
+
+        Args:
+            utxo: UTXO object.
+            tx_hash (Optional[str]): Transaction hash.
+
+        Returns:
+            PoolStateInfo: Pool state information.
+        """
+        if tx_hash:
+            tx_info = self.api.transaction(tx_hash)
+        return PoolStateInfo(
+            address=utxo.address,
+            tx_hash=tx_hash if tx_hash else utxo.tx_hash,
+            tx_index=utxo.output_index,
+            block_time=tx_info.block_time if tx_hash else 0,
+            block_index=tx_info.index if tx_hash else 0,
+            block_hash=tx_info.block if tx_hash else utxo.block,
+            datum_hash=utxo.data_hash,
+            datum_cbor=(
+                utxo.inline_datum
+                if utxo.inline_datum
+                else self._get_datum_from_datum_hash(utxo.data_hash)
+            ),
+            assets=self._format_assets(utxo.amount),
+            plutus_v2=utxo.reference_script_hash is not None,
+        )
+
+    def _format_assets(self, amount) -> Assets:
+        """Format assets from BlockFrost format to Assets model.
+
+        Args:
+            amount: BlockFrost asset amount.
+
+        Returns:
+            Assets: Formatted assets.
+        """
+        formatted_assets = {}
+        for asset in amount:
+            if asset.unit == "lovelace":
+                formatted_assets["lovelace"] = int(asset.quantity)
+            else:
+                formatted_assets[asset.unit] = int(asset.quantity)
+        return Assets(root=formatted_assets)
+
+    def _get_block_time(self, block_hash: str) -> int:
+        """Get block time from block hash.
+        You might want to cache this information to avoid repeated API calls
+
+        Args:
+            block_hash (str): Block hash.
+
+        Returns:
+            int: Block time.
+        """
+        block_info = self.api.block(block_hash)
+        return block_info.time
+
+    def _get_block_index(self, block_hash: str) -> int:
+        """Get block index from block hash.
+        You might want to cache this information to avoid repeated API calls
+
+        Args:
+            block_hash (str): Block hash.
+
+        Returns:
+            int: Block index.
+        """
+        block_info = self.api.block(block_hash)
+        return block_info.height
+
+    def _get_datum_from_datum_hash(self, datum_hash: str) -> str:
+        """Get datum CBOR from datum hash.
+
+        Args:
+            datum_hash (str): Datum hash.
+
+        Returns:
+            str: Datum CBOR.
+        """
+        datum = self.api.script_datum_cbor(datum_hash)
+        return datum.cbor

--- a/src/charli3_dendrite/backend/blockfrost/models.py
+++ b/src/charli3_dendrite/backend/blockfrost/models.py
@@ -1,0 +1,47 @@
+"""Pydantic models for the Blockfrost API."""
+
+from typing import Optional
+
+from charli3_dendrite.dataclasses.models import BaseList
+from charli3_dendrite.dataclasses.models import DendriteBaseModel
+
+
+class AssetAmount(DendriteBaseModel):
+    """Model for the asset amount in a UTxO."""
+
+    unit: str
+    quantity: str
+
+
+class UTxO(DendriteBaseModel):
+    """Model for the UTxO data."""
+
+    address: str
+    tx_hash: str
+    output_index: int
+    amount: list[AssetAmount]
+    block: str
+    data_hash: Optional[str] = None
+    inline_datum: Optional[str] = None
+    reference_script_hash: Optional[str] = None
+
+
+class UTxOList(BaseList):
+    """Model for the UTxO list data."""
+
+    root: list[UTxO]
+
+
+class TransactionInfo(DendriteBaseModel):
+    """Model for the transaction info data."""
+
+    block_time: int
+    index: int
+    block: str
+
+
+class BlockFrostBlockInfo(DendriteBaseModel):
+    """Model for the block info data."""
+
+    time: int
+    height: int

--- a/src/charli3_dendrite/backend/ogmios_kupo.py
+++ b/src/charli3_dendrite/backend/ogmios_kupo.py
@@ -1,16 +1,16 @@
 """Backend that uses Ogmios for chain context and Kupo for pool state information."""
 
-from datetime import datetime
 import logging
+from datetime import datetime
 from typing import Any
 from typing import List
 from typing import Optional
 from typing import Union
 
 import requests
+from ogmios import OgmiosChainContext
 from pycardano import Address
 from pycardano import Network
-from ogmios import OgmiosChainContext
 
 from charli3_dendrite.backend.backend_base import AbstractBackend
 from charli3_dendrite.dataclasses.models import Assets
@@ -47,7 +47,7 @@ class OgmiosKupoBackend(AbstractBackend):
         _, ws_string = ogmios_url.split("ws://")
         self.ws_url, self.port = ws_string.split(":")
         self.ogmios_context = OgmiosChainContext(
-            host=self.ws_url, port=int(self.port), network=network
+            host=self.ws_url, port=int(self.port), network=network,
         )
         self.kupo_url = kupo_url
 
@@ -211,7 +211,7 @@ class OgmiosKupoBackend(AbstractBackend):
             block_data[header_hash]["tx_hashes"].add(tx_hash)
 
         sorted_blocks = sorted(
-            block_data.items(), key=lambda x: x[1]["slot_no"], reverse=True
+            block_data.items(), key=lambda x: x[1]["slot_no"], reverse=True,
         )[:last_n_blocks]
 
         blocks = []
@@ -230,7 +230,7 @@ class OgmiosKupoBackend(AbstractBackend):
                     block_no=current_block_no,
                     tx_count=len(block_info["tx_hashes"]),
                     block_time=block_time,
-                )
+                ),
             )
 
         return BlockList(root=blocks)
@@ -347,7 +347,7 @@ class OgmiosKupoBackend(AbstractBackend):
             NotImplementedError: This method is not implemented.
         """
         raise NotImplementedError(
-            "This method is not supported due to limited data availability in Kupo"
+            "This method is not supported due to limited data availability in Kupo",
         )
 
     def get_order_utxos_by_block_or_tx(
@@ -368,7 +368,7 @@ class OgmiosKupoBackend(AbstractBackend):
             NotImplementedError: This method is not implemented.
         """
         raise NotImplementedError(
-            "This method is not supported due to limited data availability in Kupo"
+            "This method is not supported due to limited data availability in Kupo",
         )
 
     def get_cancel_utxos(
@@ -387,11 +387,11 @@ class OgmiosKupoBackend(AbstractBackend):
             NotImplementedError: This method is not implemented.
         """
         raise NotImplementedError(
-            "This method is not supported due to limited data availability in Kupo"
+            "This method is not supported due to limited data availability in Kupo",
         )
 
     def get_datum_from_address(
-        self, address: str, asset: Optional[str] = None
+        self, address: str, asset: Optional[str] = None,
     ) -> Optional[ScriptReference]:
         """Get datum from a given address.
 

--- a/src/charli3_dendrite/backend/ogmios_kupo.py
+++ b/src/charli3_dendrite/backend/ogmios_kupo.py
@@ -47,7 +47,9 @@ class OgmiosKupoBackend(AbstractBackend):
         _, ws_string = ogmios_url.split("ws://")
         self.ws_url, self.port = ws_string.split(":")
         self.ogmios_context = OgmiosChainContext(
-            host=self.ws_url, port=int(self.port), network=network,
+            host=self.ws_url,
+            port=int(self.port),
+            network=network,
         )
         self.kupo_url = kupo_url
 
@@ -211,7 +213,9 @@ class OgmiosKupoBackend(AbstractBackend):
             block_data[header_hash]["tx_hashes"].add(tx_hash)
 
         sorted_blocks = sorted(
-            block_data.items(), key=lambda x: x[1]["slot_no"], reverse=True,
+            block_data.items(),
+            key=lambda x: x[1]["slot_no"],
+            reverse=True,
         )[:last_n_blocks]
 
         blocks = []
@@ -391,7 +395,9 @@ class OgmiosKupoBackend(AbstractBackend):
         )
 
     def get_datum_from_address(
-        self, address: str, asset: Optional[str] = None,
+        self,
+        address: str,
+        asset: Optional[str] = None,
     ) -> Optional[ScriptReference]:
         """Get datum from a given address.
 

--- a/src/charli3_dendrite/backend/ogmios_kupo.py
+++ b/src/charli3_dendrite/backend/ogmios_kupo.py
@@ -1,0 +1,522 @@
+"""Backend that uses Ogmios for chain context and Kupo for pool state information."""
+
+from datetime import datetime
+import logging
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import Union
+
+import requests
+from pycardano import Address
+from pycardano import Network
+from ogmios import OgmiosChainContext
+
+from charli3_dendrite.backend.backend_base import AbstractBackend
+from charli3_dendrite.dataclasses.models import Assets
+from charli3_dendrite.dataclasses.models import BlockInfo
+from charli3_dendrite.dataclasses.models import BlockList
+from charli3_dendrite.dataclasses.models import PoolStateInfo
+from charli3_dendrite.dataclasses.models import PoolStateList
+from charli3_dendrite.dataclasses.models import ScriptReference
+from charli3_dendrite.dataclasses.models import SwapTransactionList
+
+SHELLEY_START = 1596491091
+SLOT_LENGTH = 1
+SHELLEY_SLOT_OFFSET = 4924800
+
+logger = logging.getLogger(__name__)
+
+
+class OgmiosKupoBackend(AbstractBackend):
+    """Backend that uses Ogmios for chain context and Kupo for pool state information."""
+
+    def __init__(
+        self,
+        ogmios_url: str,
+        kupo_url: str,
+        network: Network,
+    ) -> None:
+        """Initialize the OgmiosKupoBackend.
+
+        Args:
+            ogmios_url (str): URL for the Ogmios service.
+            kupo_url (str): URL for the Kupo service.
+            network (Network): The Cardano network to use.
+        """
+        _, ws_string = ogmios_url.split("ws://")
+        self.ws_url, self.port = ws_string.split(":")
+        self.ogmios_context = OgmiosChainContext(
+            host=self.ws_url, port=int(self.port), network=network
+        )
+        self.kupo_url = kupo_url
+
+    def _kupo_request(self, endpoint: str, params: Optional[dict] = None) -> Any:
+        """Make a request to the Kupo API.
+
+        Args:
+            endpoint (str): The API endpoint to request.
+            params (Optional[dict]): Query parameters for the request.
+
+        Returns:
+            Any: The JSON response from the API.
+
+        Raises:
+            requests.exceptions.RequestException: If the request fails.
+        """
+        url = f"{self.kupo_url}/{endpoint}"
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def _pool_state_from_kupo(self, match_data: dict) -> PoolStateInfo:
+        """Convert Kupo match data to PoolStateInfo.
+
+        Args:
+            match_data (dict): The match data from Kupo.
+
+        Returns:
+            PoolStateInfo: The converted pool state information.
+        """
+        assets = self._format_assets(match_data["value"])
+
+        current_slot = match_data["created_at"]["slot_no"]
+        block_time = SHELLEY_START + current_slot - 4924800
+
+        datum_hash = match_data.get("datum_hash")
+        datum_cbor = self._get_datum_cbor(datum_hash) if datum_hash else ""
+
+        return PoolStateInfo(
+            address=match_data["address"],
+            tx_hash=match_data["transaction_id"],
+            tx_index=match_data["output_index"],
+            block_time=block_time,
+            block_index=match_data["transaction_index"],
+            block_hash=match_data["created_at"]["header_hash"],
+            datum_hash=datum_hash,
+            datum_cbor=datum_cbor,
+            assets=assets,
+            plutus_v2=match_data.get("script_hash") is not None,
+        )
+
+    def get_pool_utxos(
+        self,
+        assets: Optional[List[str]] = None,
+        addresses: Optional[List[str]] = None,
+        limit: int = 1000,
+        page: int = 0,
+        historical: bool = True,
+    ) -> PoolStateList:
+        """Get pool UTXOs based on assets and addresses.
+
+        Args:
+            assets (Optional[List[str]]): List of asset IDs to filter by.
+            addresses (Optional[List[str]]): List of addresses to query.
+            limit (int): Maximum number of UTXOs to return.
+            page (int): Page number for pagination.
+            historical (bool): Whether to include historical data.
+
+        Returns:
+            PoolStateList: List of pool states.
+        """
+        pool_states = []
+        if addresses is None:
+            return PoolStateList(root=[])
+
+        for address in addresses:
+            params = {
+                "limit": limit,
+                "offset": page * limit,
+            }
+            if assets:
+                params["policy_id"] = assets[0][:56]
+                params["asset_name"] = assets[0][56:] if len(assets[0]) > 56 else None
+
+            matches = self._kupo_request(f"matches/{address}?unspent", params=params)
+
+            for match in matches:
+                pool_state = self._pool_state_from_kupo(match)
+                pool_states.append(pool_state)
+
+        return PoolStateList(root=pool_states)
+
+    def get_pool_in_tx(
+        self,
+        tx_hash: str,
+        assets: Optional[List[str]] = None,
+        addresses: Optional[List[str]] = None,
+    ) -> PoolStateList:
+        """Get pool states for a specific transaction.
+
+        Args:
+            tx_hash (str): The transaction hash to query.
+            assets (Optional[List[str]]): List of asset IDs to filter by.
+            addresses (Optional[List[str]]): List of addresses to query.
+
+        Returns:
+            PoolStateList: List of pool states for the transaction.
+        """
+        pool_states = []
+        if addresses is None:
+            return PoolStateList(root=[])
+
+        for address in addresses:
+            params = {"transaction_id": tx_hash, "order": "most_recent_first"}
+            if assets:
+                params["policy_id"] = assets[0][:56]
+                params["asset_name"] = assets[0][56:] if len(assets[0]) > 56 else None
+
+            matches = self._kupo_request(f"matches/{address}", params=params)
+
+            for match in matches:
+                pool_state = self._pool_state_from_kupo(match)
+                pool_states.append(pool_state)
+
+        return PoolStateList(root=pool_states)
+
+    def last_block(self, last_n_blocks: int = 2) -> BlockList:
+        """Get information about the last n blocks.
+
+        Args:
+            last_n_blocks (int): Number of recent blocks to retrieve.
+
+        Returns:
+            BlockList: List of recent block information.
+        """
+        ogmios_health = self._ogmios_request("health")
+        latest_slot = ogmios_health["lastKnownTip"]["slot"]
+        latest_block_no = ogmios_health["lastKnownTip"]["height"]
+        current_epoch_slot = ogmios_health["slotInEpoch"]
+
+        # Calculate the range for Kupo query
+        created_before = latest_slot + 1
+        created_after = latest_slot - (last_n_blocks * 20)
+
+        # Query Kupo for UTXOs created during the time period
+        kupo_matches = self._kupo_request(
+            "matches",
+            params={
+                "created_after": created_after,
+                "created_before": created_before,
+            },
+        )
+
+        block_data = {}
+        for match in kupo_matches:
+            header_hash = match["created_at"]["header_hash"]
+            slot_no = match["created_at"]["slot_no"]
+            tx_hash = match["transaction_id"]
+            if header_hash not in block_data:
+                block_data[header_hash] = {"slot_no": slot_no, "tx_hashes": set()}
+            block_data[header_hash]["tx_hashes"].add(tx_hash)
+
+        sorted_blocks = sorted(
+            block_data.items(), key=lambda x: x[1]["slot_no"], reverse=True
+        )[:last_n_blocks]
+
+        blocks = []
+        for i, (header_hash, block_info) in enumerate(sorted_blocks):
+            current_slot = block_info["slot_no"]
+            current_block_no = latest_block_no - i
+
+            slot_diff = latest_slot - current_slot
+            epoch_slot = (current_epoch_slot - slot_diff) % 432000
+
+            block_time = SHELLEY_START + current_slot - 4924800
+
+            blocks.append(
+                BlockInfo(
+                    epoch_slot_no=epoch_slot,
+                    block_no=current_block_no,
+                    tx_count=len(block_info["tx_hashes"]),
+                    block_time=block_time,
+                )
+            )
+
+        return BlockList(root=blocks)
+
+    def _ogmios_request(self, endpoint: str) -> dict:
+        """Make a request to the Ogmios API.
+
+        Args:
+            endpoint (str): The API endpoint to request.
+
+        Returns:
+            dict: The JSON response from the API.
+
+        Raises:
+            requests.exceptions.RequestException: If the request fails.
+        """
+        url = f"http://{self.ws_url}:{self.port}/{endpoint}"
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def get_pool_utxos_in_block(self, block_no: int, block_time: int) -> PoolStateList:
+        """Get pool UTXOs created in a specific block.
+
+        Args:
+            block_no (int): The block number to query.
+            block_time (int): The block time.
+
+        Returns:
+            PoolStateList: List of pool state objects for the block.
+        """
+        block_slot = block_time - SHELLEY_START + 4924800
+        params = {"created_after": block_slot, "order": "most_recent_first"}
+        matches = self._kupo_request("matches", params=params)
+        pool_states = [
+            self._pool_state_from_kupo(match)
+            for match in matches
+            if match.get("datum_hash")
+        ]
+        return PoolStateList(root=pool_states)
+
+    def get_script_from_address(self, address: Address) -> ScriptReference:
+        """Get script reference for a given address.
+
+        Args:
+            address (Address): The address to query.
+
+        Returns:
+            ScriptReference: Script reference for the address.
+        """
+        script_hash = address.payment_part.payload.hex()
+        script_data = self._kupo_request(f"scripts/{script_hash}")
+
+        if script_data is None:
+            return ScriptReference(
+                tx_hash=None,
+                tx_index=None,
+                address=None,
+                assets=None,
+                datum_hash=None,
+                datum_cbor=None,
+                script=None,
+            )
+
+        return ScriptReference(
+            tx_hash=None,
+            tx_index=None,
+            address=None,
+            assets=None,
+            datum_hash=None,
+            datum_cbor=None,
+            script=script_data["script"],
+        )
+
+    def _time_to_slot(self, time_value: Union[int, datetime]) -> int:
+        """Convert a time value (Unix timestamp or datetime) to a slot number.
+
+        Args:
+            time_value (Union[int, datetime]): The time value to convert.
+
+        Returns:
+            int: The slot number.
+        """
+        if isinstance(time_value, datetime):
+            unix_time = int(time_value.timestamp())
+        elif isinstance(time_value, int):
+            unix_time = time_value
+
+        return ((unix_time - SHELLEY_START) // SLOT_LENGTH) + SHELLEY_SLOT_OFFSET
+
+    def _slot_to_time(self, slot: int) -> int:
+        """Convert a slot number to a Unix timestamp.
+
+        Args:
+            slot (int): The slot number to convert.
+
+        Returns:
+            int: The Unix timestamp.
+        """
+        return SHELLEY_START + (slot - SHELLEY_SLOT_OFFSET) * SLOT_LENGTH
+
+    def get_historical_order_utxos(
+        self,
+        stake_addresses: List[str],
+        after_time: Optional[Union[datetime, int]] = None,
+        limit: int = 1000,
+        page: int = 0,
+    ) -> SwapTransactionList:
+        """Get historical order UTXOs.
+
+        This method is not supported due to limited data availability in Kupo.
+
+        Raises:
+            NotImplementedError: This method is not implemented.
+        """
+        raise NotImplementedError(
+            "This method is not supported due to limited data availability in Kupo"
+        )
+
+    def get_order_utxos_by_block_or_tx(
+        self,
+        stake_addresses: List[str],
+        out_tx_hash: Optional[List[str]] = None,
+        in_tx_hash: Optional[List[str]] = None,
+        block_no: Optional[int] = None,
+        after_block: Optional[int] = None,
+        limit: int = 1000,
+        page: int = 0,
+    ) -> SwapTransactionList:
+        """Get order UTXOs by block or transaction.
+
+        This method is not supported due to limited data availability in Kupo.
+
+        Raises:
+            NotImplementedError: This method is not implemented.
+        """
+        raise NotImplementedError(
+            "This method is not supported due to limited data availability in Kupo"
+        )
+
+    def get_cancel_utxos(
+        self,
+        stake_addresses: List[str],
+        block_no: Optional[int] = None,
+        after_time: Optional[Union[datetime, int]] = None,
+        limit: int = 1000,
+        page: int = 0,
+    ) -> SwapTransactionList:
+        """Get cancelled order UTXOs.
+
+        This method is not supported due to limited data availability in Kupo.
+
+        Raises:
+            NotImplementedError: This method is not implemented.
+        """
+        raise NotImplementedError(
+            "This method is not supported due to limited data availability in Kupo"
+        )
+
+    def get_datum_from_address(
+        self, address: str, asset: Optional[str] = None
+    ) -> Optional[ScriptReference]:
+        """Get datum from a given address.
+
+        Args:
+            address (str): The address to query.
+            asset (Optional[str]): Asset to filter by.
+
+        Returns:
+            Optional[ScriptReference]: The datum associated with the address, if any.
+        """
+        params = {"unspent": None, "order": "most_recent_first"}
+        if asset:
+            params["policy_id"] = asset[:56]
+            params["asset_name"] = asset[56:] if len(asset) > 56 else None
+
+        matches = self._kupo_request(f"matches/{address}", params=params)
+        if matches:
+            match = matches[0]
+            datum_hash = match.get("datum_hash")
+            if datum_hash:
+                datum = self._kupo_request(f"datums/{datum_hash}")
+                assets = self._format_assets(match["value"])
+                return ScriptReference(
+                    tx_hash=match["transaction_id"],
+                    tx_index=match["output_index"],
+                    address=address.encode(),
+                    assets=assets,
+                    datum_hash=datum_hash,
+                    datum_cbor=datum["datum"],
+                    script=None,
+                )
+        return None
+
+    def get_axo_target(
+        self,
+        assets: Assets,
+        block_time: Optional[datetime] = None,
+    ) -> Optional[str]:
+        """Get the target address for the given asset."""
+        # Extract policy and name from assets
+        policy = assets.unit()[:56]
+        name = assets.unit()[56:]
+        asset_id = f"{policy}.{name}"
+
+        # Prepare parameters for Kupo request
+        params = {
+            "policy_id": policy,
+            "asset_name": name if name else None,
+            "order": "most_recent_first",
+        }
+
+        if block_time:
+            params["created_before"] = self._time_to_slot(block_time)
+
+        try:
+            # Query Kupo for matches
+            matches = self._kupo_request(
+                "matches/55ff0e63efa0694e8065122c552e80c7b51768b7f20917af25752a7c/*",
+                params=params,
+            )
+
+            # Filter and process matches
+            for match in matches:
+                # Query all outputs for the transaction
+                tx_outputs = self._kupo_request(f"matches/*@{match['transaction_id']}")
+
+                # Find the first output that contains the asset and is not an AXO address
+                for output in tx_outputs:
+                    output_payment_cred = self.get_payment_credential(output["address"])
+                    if (
+                        asset_id in output["value"].get("assets", {})
+                        and output_payment_cred
+                        != "55ff0e63efa0694e8065122c552e80c7b51768b7f20917af25752a7c"
+                    ):
+                        return output["address"]
+
+            # If no suitable address found
+            return None
+
+        except Exception as e:
+            logger.error("Error in get_axo_target: %s", e)
+            return None
+
+    def _format_assets(self, value: dict) -> Assets:
+        """Format assets from Kupo format to Assets model.
+
+        Args:
+            value (dict): Asset value from Kupo.
+
+        Returns:
+            Assets: Formatted assets.
+        """
+        formatted_assets = {"lovelace": value["coins"]}
+        for asset_id, amount in value.get("assets", {}).items():
+            policy_id, asset_name = (
+                asset_id.split(".", 1) if "." in asset_id else (asset_id, "")
+            )
+            formatted_asset_id = f"{policy_id}{asset_name}"
+            formatted_assets[formatted_asset_id] = amount
+        return Assets(root=formatted_assets)
+
+    def _get_datum_cbor(self, datum_hash: Optional[str]) -> Optional[str]:
+        """Get datum CBOR from datum hash.
+
+        Args:
+            datum_hash (Optional[str]): The datum hash.
+
+        Returns:
+            Optional[str]: The datum CBOR if found, None otherwise.
+        """
+        if datum_hash:
+            try:
+                datum_data = self._kupo_request(f"datums/{datum_hash}")
+                return datum_data["datum"]
+            except Exception as e:
+                logger.error("Error fetching datum CBOR: %s", e)
+        return None
+
+    def get_payment_credential(self, cardano_address: str) -> str:
+        """Get the payment credential from a Cardano address string.
+
+        Args:
+            cardano_address (str): The Cardano address string.
+
+        Returns:
+            str: The payment credential.
+        """
+        return Address.from_primitive(cardano_address).payment_part.payload.hex()

--- a/src/charli3_dendrite/backend/ogmios_kupo/models.py
+++ b/src/charli3_dendrite/backend/ogmios_kupo/models.py
@@ -1,0 +1,67 @@
+"""Pydantic models for the Kupo response data."""
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import Field  # type: ignore
+from pydantic import RootModel
+
+from charli3_dendrite.dataclasses.models import Assets
+from charli3_dendrite.dataclasses.models import DendriteBaseModel
+
+
+class CreatedAtSpentAt(DendriteBaseModel):
+    """Created at and spent at times for Kupo response."""
+
+    slot_no: int
+    header_hash: str
+
+
+class AssetValue(DendriteBaseModel):
+    """Asset value for Kupo response."""
+
+    coins: int
+    assets: dict[str, int] = Field(default_factory=dict)
+
+
+class DatumType(str, Enum):
+    """Datum type for Kupo response."""
+
+    HASH = "hash"
+    INLINE = "inline"
+
+
+class KupoResponse(DendriteBaseModel):
+    """Kupo response data model."""
+
+    transaction_index: int
+    transaction_id: str
+    output_index: int
+    address: str
+    value: AssetValue
+    datum_hash: Optional[str] = None
+    datum_type: Optional[DatumType] = None
+    script_hash: Optional[str] = None
+    created_at: CreatedAtSpentAt
+    spent_at: Optional[CreatedAtSpentAt] = None
+
+
+class KupoResponseList(RootModel):
+    """Root model for Kupo response list."""
+
+    root: list[KupoResponse]
+
+
+class PoolStateInfo(DendriteBaseModel):
+    """Pool state info for Kupo response."""
+
+    address: str
+    tx_hash: str
+    tx_index: int
+    block_time: int
+    block_index: int
+    block_hash: str
+    datum_hash: Optional[str] = None
+    datum_cbor: str = ""
+    assets: Assets
+    plutus_v2: bool

--- a/tests/test_blockfrost.py
+++ b/tests/test_blockfrost.py
@@ -1,0 +1,107 @@
+"""Tests for the BlockFrost backend."""
+
+import os
+import pytest
+from pycardano import Address
+
+from charli3_dendrite.backend import get_backend, set_backend
+from charli3_dendrite.backend.blockfrost import BlockFrostBackend
+from charli3_dendrite.dataclasses.models import PoolStateList
+from charli3_dendrite.dexs.amm.sundae import SundaeSwapCPPState
+
+
+@pytest.fixture(scope="module")
+def blockfrost_backend() -> BlockFrostBackend:
+    """Fixture to set up and return a BlockFrost backend instance."""
+    project_id = os.environ.get("PROJECT_ID")
+    if not project_id:
+        pytest.skip("BLOCKFROST_PROJECT_ID environment variable not set")
+    backend = BlockFrostBackend(project_id)
+    set_backend(backend)
+    return backend
+
+
+@pytest.fixture(autouse=True)
+def use_blockfrost_backend(blockfrost_backend):
+    """Ensure BlockFrost backend is used for all tests in this file."""
+    set_backend(blockfrost_backend)
+    assert isinstance(get_backend(), BlockFrostBackend)
+    yield
+
+
+def test_get_pool_utxos() -> None:
+    """Test the get_pool_utxos method."""
+    selector = SundaeSwapCPPState.pool_selector()
+    selector_dict = selector.model_dump()
+
+    existing_assets = selector_dict.pop("assets", [])
+    if existing_assets is None:
+        existing_assets = []
+    elif not isinstance(existing_assets, list):
+        existing_assets = [existing_assets]
+
+    specific_asset = (
+        "8e51398904a5d3fc129fbf4f1589701de23c7824d5c90fdb9490e15a434841524c4933"
+    )
+    assets = existing_assets + [specific_asset]
+    result = get_backend().get_pool_utxos(
+        limit=100, historical=False, assets=assets, **selector_dict
+    )
+    assert isinstance(result, PoolStateList)
+    assert len(result) > 0
+    assert all(hasattr(pool, "address") for pool in result)
+
+
+def test_get_pool_in_tx() -> None:
+    """Test the get_pool_in_tx method."""
+    tx_hash = "14e59f304767ea9a659fe3dce74c1ea3837652b5008fab0bd6c56b023ad3f227"
+    selector = SundaeSwapCPPState.pool_selector()
+    result = get_backend().get_pool_in_tx(tx_hash, **selector.model_dump())
+    assert isinstance(result, PoolStateList)
+    assert len(result) > 0
+
+
+def test_last_block() -> None:
+    """Test the last_block method."""
+    result = get_backend().last_block(last_n_blocks=2)
+    assert len(result) == 2
+    assert all(hasattr(block, "block_no") for block in result)
+
+
+def test_get_pool_utxos_in_block() -> None:
+    """Test the get_pool_utxos_in_block method."""
+    result = get_backend().get_pool_utxos_in_block(10674256)
+    assert isinstance(result, PoolStateList)
+    assert len(result) > 0
+
+
+def test_get_script_from_address() -> None:
+    """Test the get_script_from_address method."""
+    address = Address.from_primitive(
+        "addr1w9qzpelu9hn45pefc0xr4ac4kdxeswq7pndul2vuj59u8tqaxdznu",
+    )
+    result = get_backend().get_script_from_address(address)
+    assert result is not None
+    assert hasattr(result, "script")
+
+
+def test_get_datum_from_address() -> None:
+    """Test the get_datum_from_address method."""
+    address = Address.from_primitive(
+        "addr1wyxq728k9pka686lzfkdyv60marz94swec9ef9mkxfqhyfqezqyjz",
+    )
+    result = get_backend().get_datum_from_address(address)
+    assert result is not None
+    assert hasattr(result, "datum_cbor")
+
+
+def test_not_implemented_methods() -> None:
+    """Test methods that are not implemented in BlockFrost backend."""
+    with pytest.raises(NotImplementedError):
+        get_backend().get_historical_order_utxos(["stake_address"])
+
+    with pytest.raises(NotImplementedError):
+        get_backend().get_order_utxos_by_block_or_tx(["stake_address"])
+
+    with pytest.raises(NotImplementedError):
+        get_backend().get_cancel_utxos(["stake_address"])

--- a/tests/test_ogmios_kupo.py
+++ b/tests/test_ogmios_kupo.py
@@ -1,0 +1,159 @@
+"""Tests for the Ogmios-Kupo backend."""
+
+import os
+import pytest
+from pycardano import Address, Network
+
+from charli3_dendrite.backend import get_backend, set_backend
+from charli3_dendrite.backend.ogmios_kupo import OgmiosKupoBackend
+from charli3_dendrite.dataclasses.models import PoolStateList, Assets
+from charli3_dendrite.dexs.amm.sundae import SundaeSwapCPPState
+
+
+@pytest.fixture(scope="module")
+def ogmios_kupo_backend() -> OgmiosKupoBackend:
+    """Fixture to set up and return an Ogmios-Kupo backend instance."""
+    ogmios_url = os.environ.get("OGMIOS_URL")
+    kupo_url = os.environ.get("KUPO_URL")
+    if not ogmios_url or not kupo_url:
+        pytest.skip("OGMIOS_URL or KUPO_URL environment variable not set")
+    backend = OgmiosKupoBackend(
+        ogmios_url=ogmios_url,
+        kupo_url=kupo_url,
+        network=Network.MAINNET,
+    )
+    set_backend(backend)
+    return backend
+
+
+@pytest.fixture(autouse=True)
+def use_ogmios_kupo_backend(ogmios_kupo_backend):
+    """Ensure Ogmios-Kupo backend is used for all tests in this file."""
+    set_backend(ogmios_kupo_backend)
+    assert isinstance(get_backend(), OgmiosKupoBackend)
+    yield
+
+
+def test_get_pool_utxos() -> None:
+    """Test the get_pool_utxos method."""
+    selector = SundaeSwapCPPState.pool_selector()
+    selector_dict = selector.model_dump()
+
+    existing_assets = selector_dict.pop("assets", [])
+    if existing_assets is None:
+        existing_assets = []
+    elif not isinstance(existing_assets, list):
+        existing_assets = [existing_assets]
+
+    specific_asset = (
+        "8e51398904a5d3fc129fbf4f1589701de23c7824d5c90fdb9490e15a434841524c4933"
+    )
+    assets = existing_assets + [specific_asset]
+    result = get_backend().get_pool_utxos(
+        limit=100, historical=False, assets=assets, **selector_dict
+    )
+    assert isinstance(result, PoolStateList)
+    assert len(result) > 0
+    assert all(hasattr(pool, "address") for pool in result)
+
+
+def test_get_pool_in_tx() -> None:
+    """Test the get_pool_in_tx method."""
+    # First, get a recent pool UTxO
+    selector = SundaeSwapCPPState.pool_selector()
+    selector_dict = selector.model_dump()
+
+    existing_assets = selector_dict.pop("assets", [])
+    if existing_assets is None:
+        existing_assets = []
+    elif not isinstance(existing_assets, list):
+        existing_assets = [existing_assets]
+
+    specific_asset = (
+        "8e51398904a5d3fc129fbf4f1589701de23c7824d5c90fdb9490e15a434841524c4933"
+    )
+    assets = existing_assets + [specific_asset]
+    recent_pools = get_backend().get_pool_utxos(
+        limit=100, historical=False, assets=assets, **selector_dict
+    )
+
+    assert len(recent_pools) > 0, "No recent pool UTxOs found"
+
+    recent_tx_hash = recent_pools[0].tx_hash
+    assert recent_tx_hash, "No transaction hash found for recent pool"
+
+    # Now test get_pool_in_tx with this recent transaction
+    result = get_backend().get_pool_in_tx(recent_tx_hash, **selector.model_dump())
+
+    assert isinstance(result, PoolStateList)
+    assert len(result) > 0, f"No pool found in transaction {recent_tx_hash}"
+
+    # Additional checks to ensure the returned data is as expected
+    for pool in result:
+        assert (
+            pool.tx_hash == recent_tx_hash
+        ), f"Returned pool tx_hash {pool.tx_hash} doesn't match queried tx_hash {recent_tx_hash}"
+        assert hasattr(pool, "address"), "Pool object doesn't have 'address' attribute"
+        assert hasattr(pool, "assets"), "Pool object doesn't have 'assets' attribute"
+        assert pool.assets is not None, "Pool assets are None"
+
+    print(f"Successfully tested get_pool_in_tx with transaction: {recent_tx_hash}")
+
+
+def test_last_block() -> None:
+    """Test the last_block method."""
+    result = get_backend().last_block(last_n_blocks=2)
+    assert len(result) == 2
+    assert all(hasattr(block, "block_no") for block in result)
+
+
+def test_get_pool_utxos_in_block() -> None:
+    """Test the get_pool_utxos_in_block method."""
+    # Note: Ogmios-Kupo might require block_time as well
+    last_block = get_backend().last_block(last_n_blocks=1)[0]
+    result = get_backend().get_pool_utxos_in_block(
+        last_block.block_no, last_block.block_time
+    )
+    assert isinstance(result, PoolStateList)
+    assert len(result) >= 0
+
+
+def test_get_script_from_address() -> None:
+    """Test the get_script_from_address method."""
+    address = Address.from_primitive(
+        "addr1w9qzpelu9hn45pefc0xr4ac4kdxeswq7pndul2vuj59u8tqaxdznu",
+    )
+    result = get_backend().get_script_from_address(address)
+    assert result is not None
+    assert hasattr(result, "script")
+
+
+def test_get_datum_from_address() -> None:
+    """Test the get_datum_from_address method."""
+    address = Address.from_primitive(
+        "addr1wyxq728k9pka686lzfkdyv60marz94swec9ef9mkxfqhyfqezqyjz",
+    )
+    result = get_backend().get_datum_from_address(address)
+    assert result is not None
+    assert hasattr(result, "datum_cbor")
+
+
+def test_get_axo_target() -> None:
+    """Test the get_axo_target method."""
+    assets = Assets(
+        root={"420000029ad9527271b1b1e3c27ee065c18df70a4a4cfc3093a41a4441584f": 1}
+    )
+    result = get_backend().get_axo_target(assets)
+    assert isinstance(result, str) or result is None
+
+
+def test_not_implemented_methods() -> None:
+    """Test methods that are not implemented in Ogmios-Kupo backend."""
+    with pytest.raises(NotImplementedError):
+        get_backend().get_historical_order_utxos(["stake_address"])
+
+    with pytest.raises(NotImplementedError):
+        get_backend().get_order_utxos_by_block_or_tx(["stake_address"])
+
+    with pytest.raises(NotImplementedError):
+        get_backend().get_cancel_utxos(["stake_address"])


### PR DESCRIPTION
This PR introduces support for two new backend implementations: BlockFrost and Ogmios-Kupo. These additions provide more flexibility for users to interact with the Cardano blockchain using different data sources.

## Key Changes

1. Added `BlockFrostBackend` class in `src/charli3_dendrite/backend/blockfrost/__init__.py`
2. Added `OgmiosKupoBackend` class in `src/charli3_dendrite/backend/ogmios_kupo/__init__.py`
3. Updated the backend management module (`src/charli3_dendrite/backend/__init__.py`) to support the new backends
4. Modified the example script (`example.py`) to demonstrate usage of all available backends
5. Updated dependencies in `pyproject.toml` and `poetry.lock`
6. Added new test files: `tests/test_blockfrost.py` and `tests/test_ogmios_kupo.py`

## New Features

* Support for querying blockchain data through BlockFrost API
* Integration with Ogmios for chain context and Kupo for pool state information
* Automatic backend selection based on environment variables
* Improved error handling and logging for backend operations

## Notes

* Some methods in the BlockFrost and Ogmios-Kupo backends are not fully implemented due to limitations in their respective APIs. These methods raise `NotImplementedError` with appropriate messages.
* The example script now includes commented-out sections for each backend type, allowing users to easily switch between them for testing purposes.
* New environment variables are required for configuring BlockFrost and Ogmios-Kupo backends (e.g., `BLOCKFROST_PROJECT_ID`, `OGMIOS_URL`, `KUPO_URL`)

Please review these changes and provide feedback. Let me know if any further modifications or clarifications are needed.