### PR TITLE
FIX: Added catch for missing Axo key

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -29,7 +29,7 @@ select = [
     "NPY", # NumPy-specific rules
     "RUF", # Ruff-specific rules
 ]
-ignore = ["ANN101", "ANN102", "UP006", "ARG002", "PLR0913"]
+ignore = ["ANN101", "ANN102", "UP006", "ARG002", "PLR0913", "UP035", "S105"]
 unfixable = ["B"] # Avoid trying to fix flake8-bugbear violations.
 target-version = "py39" # Assume Python 3.9.
 extend-exclude = ["tests", "examples"]

--- a/src/charli3_dendrite/dexs/ob/axo.py
+++ b/src/charli3_dendrite/dexs/ob/axo.py
@@ -55,7 +55,7 @@ logger = logging.getLogger("cardem.api.dataclasses.axo")
 
 load_dotenv()
 
-AXO_API_KEY = os.environ["AXO_API_KEY"]
+AXO_API_KEY = os.environ.get("AXO_API_KEY", None)
 
 
 @dataclass


### PR DESCRIPTION
This PR fixes #105 

The solution is to add a default `None` return if the axo api key is missing. This allows the library to load, but will still throw an error when trying to use the Axo component unless the key is supplied.