### PR TITLE
Fix: Add missing 'path' argument to KupoOgmiosV6ChainContext

### DIFF
--- a/src/charli3_dendrite/backend/ogmios_kupo/__init__.py
+++ b/src/charli3_dendrite/backend/ogmios_kupo/__init__.py
@@ -42,6 +42,7 @@ class OgmiosKupoBackend(AbstractBackend):
         ogmios_url: str,
         kupo_url: str,
         network: Network,
+        path: str = "",
     ) -> None:
         """Initialize the OgmiosKupoBackend.
 
@@ -55,6 +56,7 @@ class OgmiosKupoBackend(AbstractBackend):
         self.ogmios_context = KupoOgmiosV6ChainContext(
             host=self.ws_url,
             port=int(self.port),
+            path=path,
             secure=False,
             refetch_chain_tip_interval=None,
             network=network,

--- a/tests/test_ogmios_kupo.py
+++ b/tests/test_ogmios_kupo.py
@@ -13,14 +13,17 @@ from charli3_dendrite.dexs.amm.sundae import SundaeSwapCPPState
 @pytest.fixture(scope="module")
 def ogmios_kupo_backend() -> OgmiosKupoBackend:
     """Fixture to set up and return an Ogmios-Kupo backend instance."""
-    ogmios_url = os.environ.get("OGMIOS_URL")
-    kupo_url = os.environ.get("KUPO_URL")
+    ogmios_url = os.environ.get("OGMIOS_URL", "")
+    kupo_url = os.environ.get("KUPO_URL", "")
+    path = os.environ.get("OGMIOS_PATH", "")
+
     if not ogmios_url or not kupo_url:
         pytest.skip("OGMIOS_URL or KUPO_URL environment variable not set")
     backend = OgmiosKupoBackend(
         ogmios_url=ogmios_url,
         kupo_url=kupo_url,
         network=Network.MAINNET,
+        path=path,
     )
     set_backend(backend)
     return backend


### PR DESCRIPTION
This PR fixes a bug in the KupoOgmiosV6ChainContext constructor by adding the missing path argument. This ensures proper instantiation and compatibility with components expecting the full set of paramete