### PR TITLE
fix(vyfi): don't double-encode hex-marked asset token names

### DIFF
--- a/src/charli3_dendrite/dexs/amm/vyfi.py
+++ b/src/charli3_dendrite/dexs/amm/vyfi.py
@@ -324,7 +324,26 @@ class VyFiCPPState(AbstractConstantProductPoolState):
 
     @staticmethod
     def _encode_asset(policy_id: str, asset_name: str) -> str:
-        """Encode an asset by combining policy ID and hex-encoded asset name."""
+        r"""Encode an asset by combining policy ID and the on-chain asset name.
+
+        VyFi's API returns ``token_name`` in two forms: a human-readable string
+        (e.g. ``"PUDGY"``), or the on-chain asset name *already hex-encoded* and
+        marked with a ``"0x"`` prefix, optionally preceded by a NUL byte
+        (e.g. ``"\x000x55534441"`` for ``"USDA"``). For the latter the hex is
+        the real on-chain asset name and must be used verbatim -- re-encoding it
+        as UTF-8 double-encodes the name and corrupts the unit, frequently
+        pushing it past the 32-byte asset-name limit (and mangling names with
+        non-UTF-8 bytes, e.g. ``"\x000xf6..."``).
+        """
+        marked = asset_name.lstrip("\x00")
+        if marked.startswith("0x"):
+            hex_name = marked[2:]
+            try:
+                bytes.fromhex(hex_name)
+            except ValueError:
+                pass
+            else:
+                return policy_id + hex_name.lower()
         encoded_name = asset_name.encode("utf-8").hex()
         return policy_id + encoded_name
 

--- a/tests/test_vyfi_encode_asset.py
+++ b/tests/test_vyfi_encode_asset.py
@@ -1,0 +1,52 @@
+"""Regression tests for ``VyFiCPPState._encode_asset`` (token-name double-encoding).
+
+VyFi's ``/lp`` API returns each asset's ``token_name`` in one of two forms:
+
+* a human-readable string (e.g. ``"PUDGY"``), or
+* the on-chain asset name *already hex-encoded* behind a ``"0x"`` marker,
+  optionally preceded by a NUL byte (e.g. ``"\x000x55534441"`` == ``"USDA"``).
+
+The previous implementation UTF-8-encoded both forms, which double-encoded the
+marked-hex form -- corrupting the unit and (for names with non-UTF-8 bytes)
+expanding it past the 32-byte on-chain asset-name limit. These tests pin the
+correct behaviour for both forms.
+"""
+
+from charli3_dendrite.dexs.amm.vyfi import VyFiCPPState
+
+POLICY = "aa" * 28  # a 56-hex-char policy id
+
+
+def test_marked_hex_name_used_verbatim():
+    # "\x000x55534441" carries the on-chain name bytes for "USDA".
+    assert VyFiCPPState._encode_asset(POLICY, "\x000x55534441") == POLICY + "55534441"
+
+
+def test_marked_hex_without_nul_prefix():
+    assert VyFiCPPState._encode_asset(POLICY, "0x55534441") == POLICY + "55534441"
+
+
+def test_marked_hex_non_utf8_name_not_mangled():
+    # A name with non-UTF-8 bytes (0xf6...) must survive verbatim; UTF-8
+    # re-encoding would expand/mangle it well past the 32-byte limit.
+    name_hex = "f6cee18b885e242e91e167e80a38543e58e6c6bd9a9af86e54d8ecef21c78948"
+    assert VyFiCPPState._encode_asset(POLICY, "\x000x" + name_hex) == POLICY + name_hex
+
+
+def test_uppercase_marked_hex_is_lowercased():
+    # The "0x" marker is always lowercase from the API; an uppercase hex
+    # payload must be normalised to lowercase in the on-chain unit.
+    name_hex = "446A65644D6963726F555344"  # "DjedMicroUSD", uppercased
+    assert (
+        VyFiCPPState._encode_asset(POLICY, "0x" + name_hex) == POLICY + name_hex.lower()
+    )
+
+
+def test_plain_text_name_utf8_encoded():
+    # Human-readable names retain the original UTF-8-hex behaviour.
+    assert VyFiCPPState._encode_asset(POLICY, "PUDGY") == POLICY + b"PUDGY".hex()
+
+
+def test_marked_but_invalid_hex_falls_back_to_utf8():
+    # A "0x" prefix whose remainder is not valid hex is treated as plain text.
+    assert VyFiCPPState._encode_asset(POLICY, "0xZZ") == POLICY + "0xZZ".encode().hex()


### PR DESCRIPTION
## Problem

`VyFiCPPState._encode_asset` unconditionally did `asset_name.encode("utf-8").hex()`. But VyFi's `/lp` API returns `token_name` in two different forms:

- a human-readable string, e.g. `"PUDGY"`; or
- the on-chain asset name **already hex-encoded**, behind a `"0x"` marker and (usually) a leading NUL byte — e.g. `"\x000x55534441"` for `USDA`, `"\x000x446a65644d6963726f555344"` for `DjedMicroUSD`, and binary names like `"\x000xf6cee18b…"`.

For the second form, the unconditional UTF-8 encode **double-encodes** the name: `"\x000x55534441"` becomes `0030783535353334343431` instead of `55534441`. The resulting unit is wrong, and for names carrying non-UTF-8 bytes (e.g. `0xf6…`) it also balloons past the 32-byte on-chain asset-name limit. Anything that builds or looks up units via `_encode_asset` then misses those pools/assets entirely (e.g. WorldMobileToken / WMTX).

## Fix

Detect the `"0x"` marker (after stripping a leading NUL) and, when the remainder is valid hex, use it verbatim; otherwise fall back to UTF-8 encoding for genuine plain-text names. The fallback preserves the existing behaviour for human-readable names.

## Tests

`tests/test_vyfi_encode_asset.py` (pure unit test, no backend) covers:
- marked-hex form (`\x000x…`) used verbatim,
- a non-UTF-8 binary name (which the old code mangled past 32 bytes),
- uppercase-hex normalisation,
- the plain-text UTF-8 fallback,
- a `"0x"`-prefixed but non-hex name correctly falling back to UTF-8.
