### PR TITLE
fix(minswap): populate requested_amount for V2 special order steps

### DIFF
--- a/src/charli3_dendrite/dexs/amm/minswap.py
+++ b/src/charli3_dendrite/dexs/amm/minswap.py
@@ -618,6 +618,41 @@ class MinswapV2OrderDatum(OrderDatum):
                 return Assets({"asset_b": self.step.minimum_receive})
             else:
                 return Assets({"asset_a": self.step.minimum_receive})
+        elif isinstance(self.step, StopLossV2):
+            if isinstance(self.step.a_to_b_direction, BoolTrue):
+                return Assets({"asset_b": self.step.stop_loss_receive})
+            else:
+                return Assets({"asset_a": self.step.stop_loss_receive})
+        elif isinstance(self.step, OCOV2):
+            # OCO carries a take-profit (minimum_receive) and a stop-loss
+            # (stop_loss_receive); report the take-profit limit as the requested
+            # amount, mirroring the minimum_receive used for SwapExactInV2.
+            if isinstance(self.step.a_to_b_direction, BoolTrue):
+                return Assets({"asset_b": self.step.minimum_receive})
+            else:
+                return Assets({"asset_a": self.step.minimum_receive})
+        elif isinstance(self.step, ZapOutV2):
+            if isinstance(self.step.a_to_b_direction, BoolTrue):
+                return Assets({"asset_b": self.step.minimum_receive})
+            else:
+                return Assets({"asset_a": self.step.minimum_receive})
+        elif isinstance(self.step, PartialSwapV2):
+            # PartialSwap has no minimum_receive field; io_ratio is the limit
+            # price, so the requested output is total_swap_amount scaled by
+            # io_ratio_numerator / io_ratio_denominator.
+            requested = (
+                self.step.total_swap_amount
+                * self.step.io_ratio_numerator
+                // self.step.io_ratio_denominator
+            )
+            if isinstance(self.step.a_to_b_direction, BoolTrue):
+                return Assets({"asset_b": requested})
+            else:
+                return Assets({"asset_a": requested})
+        elif isinstance(self.step, WithdrawImbalanceV2):
+            # Only asset_a carries a guaranteed minimum (minimum_asset_a); the
+            # asset_b amount is governed by the withdrawal ratio, not a floor.
+            return Assets({"asset_a": self.step.minimum_asset_a})
         else:
             return Assets({})
 

--- a/tests/test_minswapv2_requested_amount.py
+++ b/tests/test_minswapv2_requested_amount.py
@@ -1,0 +1,97 @@
+"""Regression tests for ``MinswapV2OrderDatum.requested_amount()`` on the step
+types that previously fell through to the empty ``Assets({})`` else branch.
+
+StopLossV2 / OCOV2 / ZapOutV2 / PartialSwapV2 / WithdrawImbalanceV2 are valid
+on-chain MinswapV2 order steps, but ``requested_amount()`` returned nothing for
+them, so consumers could not recover the order's ask. These tests pin the ask
+each now reports.
+"""
+
+from pycardano import Address, VerificationKeyHash
+
+from charli3_dendrite.dexs.amm.minswap import (
+    BoolFalse,
+    BoolTrue,
+    MinswapV2OrderDatum,
+    OCOV2,
+    PartialSwapV2,
+    SAOSpecificAmount,
+    StopLossV2,
+    WithdrawImbalanceV2,
+    ZapOutV2,
+)
+from charli3_dendrite.utility import Assets
+
+_ADDR = Address(
+    payment_part=VerificationKeyHash(bytes(28)),
+    staking_part=VerificationKeyHash(bytes(28)),
+)
+_IN = Assets(**{"aa" * 28: 1_000_000})
+_OUT = Assets(**{"bb" * 28: 500_000})
+
+
+def _datum_with(step) -> MinswapV2OrderDatum:
+    """A valid MinswapV2OrderDatum carrying ``step`` (other fields are dummies)."""
+    datum = MinswapV2OrderDatum.create_datum(
+        address_source=_ADDR,
+        in_assets=_IN,
+        out_assets=_OUT,
+        batcher_fee=Assets(lovelace=2_000_000),
+        deposit=Assets(lovelace=2_000_000),
+    )
+    datum.step = step
+    return datum
+
+
+def test_stop_loss_uses_stop_loss_receive():
+    step = StopLossV2(
+        a_to_b_direction=BoolTrue(),
+        swap_amount_option=SAOSpecificAmount(swap_amount=1000),
+        stop_loss_receive=900,
+    )
+    assert _datum_with(step).requested_amount() == Assets({"asset_b": 900})
+
+
+def test_oco_uses_minimum_receive_not_stop_loss():
+    step = OCOV2(
+        a_to_b_direction=BoolFalse(),
+        swap_amount_option=SAOSpecificAmount(swap_amount=1000),
+        minimum_receive=950,
+        stop_loss_receive=800,
+    )
+    assert _datum_with(step).requested_amount() == Assets({"asset_a": 950})
+
+
+def test_zap_out_uses_minimum_receive():
+    step = ZapOutV2(
+        a_to_b_direction=BoolTrue(),
+        withdrawal_amount_option=0,
+        minimum_receive=700,
+        killable=BoolFalse(),
+    )
+    assert _datum_with(step).requested_amount() == Assets({"asset_b": 700})
+
+
+def test_partial_swap_computes_from_io_ratio():
+    # 1000 * 9 // 10 == 900
+    step = PartialSwapV2(
+        a_to_b_direction=BoolTrue(),
+        total_swap_amount=1000,
+        io_ratio_numerator=9,
+        io_ratio_denominator=10,
+        hops=1,
+        minimum_swap_amount_required=100,
+        max_batcher_fee_each_time=1000,
+    )
+    assert _datum_with(step).requested_amount() == Assets({"asset_b": 900})
+
+
+def test_withdraw_imbalance_uses_minimum_asset_a():
+    step = WithdrawImbalanceV2(
+        withdrawal_amount_optino=0,
+        ratio_asset_a=1,
+        ratio_asset_b=1,
+        minimum_asset_a=600,
+        killable=BoolFalse(),
+    )
+    assert _datum_with(step).requested_amount() == Assets({"asset_a": 600})


### PR DESCRIPTION
## Problem

`MinswapV2OrderDatum.requested_amount()` handled `SwapExactInV2` / `SwapExactOutV2` / `DepositV2` / `WithdrawV2` / `SwapMultiRoutingV2`, but the remaining five valid step types fell through to the `else` and returned an empty `Assets({})`:

`StopLossV2`, `OCOV2`, `ZapOutV2`, `PartialSwapV2`, `WithdrawImbalanceV2`.

`order_type()` already classifies all five, so a consumer sees a typed order but gets no ask amount — the order's requested amount is lost.

## Fix

Add a branch for each, following the existing `a_to_b_direction → asset_b / asset_a` convention:

| step | requested amount |
|------|------------------|
| `StopLossV2` | `stop_loss_receive` |
| `OCOV2` | `minimum_receive` (take-profit leg) |
| `ZapOutV2` | `minimum_receive` |
| `PartialSwapV2` | `total_swap_amount * io_ratio_numerator // io_ratio_denominator` |
| `WithdrawImbalanceV2` | `minimum_asset_a` |

Two judgment calls worth a maintainer eye:

- **`OCOV2`** reports the take-profit `minimum_receive` (consistent with `SwapExactInV2`), rather than the `stop_loss_receive` floor.
- **`PartialSwapV2`** has no `minimum_receive` field, so the ask is *computed* from the `io_ratio` — an expected output at the limit price, not a guaranteed minimum like the others.

`WithdrawImbalanceV2` reports only `minimum_asset_a` because that's the sole field with a guaranteed floor (there is no `minimum_asset_b`; `asset_b` is governed by the ratio).

## Tests

`tests/test_minswapv2_requested_amount.py` — one case per step (pure unit test, no backend), building a datum via `create_datum` and swapping `.step`.
