### PR TITLE
feat(splash): record executor fee (_executor_fee = 3 ADA) for fillability

### DIFF
--- a/src/charli3_dendrite/dexs/amm/splash.py
+++ b/src/charli3_dendrite/dexs/amm/splash.py
@@ -269,6 +269,13 @@ class CPPoolRedeemer(PlutusData):
 class SplashBaseState(AbstractPairState):
     """Base state class for Splash DEX pools."""
 
+    # Off-chain executor fee a Splash ORDER must pay to be picked up:
+    # SplashOrderDatum.fee (2 ADA) + cost_per_ex_step (1 ADA) = 3 ADA. This is the
+    # order/executor fee (used for fillability), DISTINCT from _batcher/_deposit
+    # (=0) which the direct pool-spend swap path uses. Do NOT fold this into
+    # _batcher — downstream consumers read _batcher as the direct-swap cost.
+    _executor_fee = Assets(lovelace=3_000_000)
+
     @classmethod
     def dex(cls) -> str:
         """Return the name of the DEX."""


### PR DESCRIPTION
## What
Add `_executor_fee = Assets(lovelace=3_000_000)` to `SplashBaseState`.

A Splash order pays its off-chain executor via `SplashOrderDatum.fee` (2 ADA) +
`cost_per_ex_step` (1 ADA) = 3 ADA. Dendrite had no surface for this — `_batcher`
/`_deposit` are `0` because Splash builds direct pool spends, not orders. This
additive class constant lets consumers read the required executor fee.

## Why
SteelSwap's virtual batcher needs the executor fee an order must pay to be picked
up, to mark perpetually-underpaying orders terminal (they can never be batched).
Validated on-chain: Splash orders *executed* in the last 30 days are 100% at
exactly 3 ADA (`fee` 2M + `cost_per_ex_step` 1M).

## Scope / safety
- Purely additive: does NOT touch `_batcher`, `_deposit`, or `batcher_fee()` /
  `deposit()` — the direct pool-spend cost is unchanged.
- Inherited by all Splash subclasses (CPP, SSP, Royalty, Bidir).
- No manual version bump (bumpversion tooling handles it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
