### PR TITLE
fix(dano): skip_init re-ingest contract + carve-at-parse (round-trip idempotent)

### DIFF
--- a/src/charli3_dendrite/dexs/amm/dano.py
+++ b/src/charli3_dendrite/dexs/amm/dano.py
@@ -549,26 +549,56 @@ class DanoCLMMState(AbstractConstantLiquidityPoolState):
         return self._datum.unit_y
 
     @property
+    def _x_carve(self) -> int:
+        """Carve netted off the gross tokenX balance to get the active reserve.
+
+        The platform fee, plus min-UTxO + swap-fee on the ADA (tokenX) side.
+        """
+        d = self._datum
+        excluded_ada = ADA_MIN_UTXO + d.total_swap_fee if d.unit_x == "lovelace" else 0
+        return d.platform_fee_x + excluded_ada
+
+    @property
     def raw_x(self) -> int:
-        """Return the raw tokenX balance held in the pool UTxO."""
-        return self.assets[self._datum.unit_x]
+        """Return the raw (gross) tokenX balance held in the pool UTxO.
+
+        ``assets`` stores the *active* (carve-netted) reserves — see
+        ``post_init``/``skip_init`` — so the gross balance is reconstructed by
+        adding the carve back. The tx-build path needs gross (platform fees +
+        min-ADA stay in the pool output).
+        """
+        return self.assets[self._datum.unit_x] + self._x_carve
 
     @property
     def raw_y(self) -> int:
-        """Return the raw tokenY balance held in the pool UTxO."""
-        return self.assets[self._datum.unit_y]
+        """Return the raw (gross) tokenY balance held in the pool UTxO."""
+        return self.assets[self._datum.unit_y] + self._datum.platform_fee_y
 
     @property
     def reserve_a(self) -> int:
-        """Active reserve of tokenX, net of platform fees and ADA carve-out."""
-        d = self._datum
-        excluded_ada = ADA_MIN_UTXO + d.total_swap_fee if d.unit_x == "lovelace" else 0
-        return self.raw_x - d.platform_fee_x - excluded_ada
+        """Active reserve of tokenX (read directly — ``assets`` is carve-netted).
+
+        See ``post_init`` / ``skip_init`` for the round-trip-safe representation.
+        """
+        return self.assets[self._datum.unit_x]
 
     @property
     def reserve_b(self) -> int:
-        """Active reserve of tokenY, net of platform fees."""
-        return self.raw_y - self._datum.platform_fee_y
+        """Active reserve of tokenY (``assets`` is carve-netted at parse time)."""
+        return self.assets[self._datum.unit_y]
+
+    def _gross_assets(self) -> Assets:
+        """The raw on-chain UTxO value bag (carve added back to the reserves).
+
+        ``assets`` stores the carve-netted reserves; the tx-build path needs the
+        true gross bag so the new pool output preserves the platform fees +
+        min-ADA that stay in the pool.
+        """
+        d = self._datum
+        g = Assets(root=dict(self.assets.root))
+        g.root[d.unit_x] = g.root.get(d.unit_x, 0) + self._x_carve
+        g.root[d.unit_y] = g.root.get(d.unit_y, 0) + d.platform_fee_y
+        return g
 
     # --- math (single-band CLMM curve inherited from the base) -------------
     # ``virtual_reserves()`` + ``get_amount_out()``/``get_amount_in()`` + the
@@ -596,15 +626,10 @@ class DanoCLMMState(AbstractConstantLiquidityPoolState):
         withdrawn into the pool as part of the same tx (see docs/05-04-swap.md
         "If token_x is ADA AND curEpoch > last_withdraw_epoch").
         """
-        d = self._datum
-        x_raw = self.raw_x + staking_reward
-        y_raw = self.raw_y
-        if d.unit_x == "lovelace":
-            pool_in_lp_x = x_raw - d.platform_fee_x - d.total_swap_fee - ADA_MIN_UTXO
-        else:
-            pool_in_lp_x = x_raw - d.platform_fee_x
-        pool_in_lp_y = y_raw - d.platform_fee_y
-        return pool_in_lp_x, pool_in_lp_y
+        # The active liquidity IS the carve-netted reserve (reserve_a/reserve_b),
+        # plus any in-tx ADA staking_reward withdrawn into the pool on the X side.
+        # Equivalent to the old gross-minus-carve form, expressed in net terms.
+        return self.reserve_a + staking_reward, self.reserve_b
 
     def compute_pool_change(
         self,
@@ -713,7 +738,9 @@ class DanoCLMMState(AbstractConstantLiquidityPoolState):
         staking_reward: int = 0,
     ) -> Assets:
         d = self._datum
-        new = Assets(root=dict(self.assets.root))
+        # Build the new output from the GROSS bag — the on-chain UTxO must keep
+        # the platform fees + min-ADA that ``assets`` (net) no longer carries.
+        new = self._gross_assets()
         if self.dex_nft is not None:
             new.root[self.dex_nft.unit()] = 1
         new.root[d.unit_x] = new.root.get(d.unit_x, 0) + pool_change_x
@@ -793,7 +820,8 @@ class DanoCLMMState(AbstractConstantLiquidityPoolState):
         # Rebuild the pool input UTxO. Address is fetched from the pool tx so we
         # pick up the correct form (addr1x… or addr1w…); the addr1x delegation
         # part also carries the per-pool staking credential used below.
-        pool_in_assets = Assets(root=dict(self.assets.root))
+        # The spent pool input value is the GROSS on-chain bag (assets is net).
+        pool_in_assets = self._gross_assets()
         if self.dex_nft is not None:
             pool_in_assets.root[self.dex_nft.unit()] = 1
 
@@ -956,12 +984,52 @@ class DanoCLMMState(AbstractConstantLiquidityPoolState):
     # --- post-init ---------------------------------------------------------
 
     @classmethod
+    def skip_init(cls, values: dict[str, Any]) -> bool:
+        """Skip parsing when re-ingesting an already-parsed (dumped) pool.
+
+        A parsed Dano pool exposes its ``dex_nft`` as a separate field and stores
+        the *active* (carve-netted) reserves in ``assets`` (see ``post_init``). On
+        re-ingest the carve must NOT be applied again, so the presence of
+        ``dex_nft`` in the construction values is the "already parsed" signal:
+        surface the derived ``fee`` and skip ``post_init`` (which would re-net).
+        A fresh chain parse carries the dex NFT *inside* the assets bag (extracted
+        later), not as a ``dex_nft`` key, so it takes the full parse path. Mirrors
+        VyFi / WingRiders V2; makes the serialize→reingest round-trip idempotent
+        for both the dendrite model_dump form and steelswap's net silver.
+        """
+        if "dex_nft" in values:
+            if not isinstance(values["assets"], Assets):
+                values["assets"] = Assets.model_validate(values["assets"])
+            datum = cls.pool_datum_class().from_cbor(values["datum_cbor"])
+            values["fee"] = datum.lp_fee_rate
+            return True
+        return False
+
+    @classmethod
     def post_init(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """Post-initialization processing: surface lp_fee_rate on the model."""
+        """Post-initialization: surface ``lp_fee_rate`` and carve-net the reserves.
+
+        Subtracts the platform fee (+ ADA min-utxo + swap-fee on the ADA side)
+        from ``assets`` so the stored balances are the *active* reserves
+        (``reserve_a``/``reserve_b`` read them directly). This is the derive-once
+        step that ``skip_init`` skips on re-ingest, so the round-trip is
+        idempotent; ``raw_x``/``_gross_assets`` add the carve back for tx-build.
+        """
         values = super().post_init(values)
         # Surface lp_fee_rate on the model so `volume_fee` works out of the box.
         datum = cls.pool_datum_class().from_cbor(values["datum_cbor"])
         values["fee"] = datum.lp_fee_rate
+        # Carve-net the reserves in place (skipped on re-ingest via skip_init).
+        assets = values["assets"]
+        excluded_ada = (
+            ADA_MIN_UTXO + datum.total_swap_fee if datum.unit_x == "lovelace" else 0
+        )
+        assets.root[datum.unit_x] = (
+            assets.root.get(datum.unit_x, 0) - datum.platform_fee_x - excluded_ada
+        )
+        assets.root[datum.unit_y] = (
+            assets.root.get(datum.unit_y, 0) - datum.platform_fee_y
+        )
         return values
 
     @property

--- a/tests/test_dano_roundtrip.py
+++ b/tests/test_dano_roundtrip.py
@@ -1,0 +1,138 @@
+"""Dano serialize→re-ingest round-trip + carve byte-identity (STEEL-273).
+
+A parsed Dano pool stores the *active* (carve-netted) reserves in ``assets``
+(``post_init`` subtracts the platform fee + ADA min-utxo/swap-fee). On re-ingest
+of an already-parsed representation — a dendrite ``model_dump`` OR a downstream
+consumer's net projection (steelswap silver) — the carve must NOT be applied a
+second time. ``skip_init`` keys on the presence of the separate ``dex_nft``
+field (the "already parsed" signal) and skips ``post_init``, exactly like
+VyFi / WingRiders V2.
+
+Before this fix Dano had no ``skip_init`` and netted the carve in a *property*
+on every access, so feeding back the stored (net) reserves double-subtracted —
+silently, since the curve was self-consistent on the wrong reserves.
+
+The byte-identity test pins that the refactor (which moved the carve from a
+property into ``post_init``, making ``assets`` net) did not change any
+externally-observable value — the curve (``get_amount_out``) and the tx-build
+asset bag (``_new_pool_assets``) are identical to before, with the gross balance
+reconstructed for tx-build via ``raw_x`` / ``_gross_assets``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from charli3_dendrite.dataclasses.models import Assets
+from charli3_dendrite.dexs.amm.dano import DanoCLMMState
+
+_FIX = json.loads(
+    (Path(__file__).parent / "data" / "dano_pool_fixtures.json").read_text()
+)
+
+
+def _pool(key: str) -> DanoCLMMState:
+    return DanoCLMMState.model_validate(_FIX[key]["row"])
+
+
+def _net_reingest(p: DanoCLMMState) -> DanoCLMMState:
+    """Reconstruct ``p`` from its NET reserves + dex_nft (the steelswap silver
+    shape): the exact case that double-subtracted before ``skip_init``.
+    """
+    d = p._datum
+    values = dict(p.model_dump())
+    values["assets"] = Assets(
+        root={d.unit_x: p.reserve_a, d.unit_y: p.reserve_b, "lovelace": 2_000_000},
+    )
+    return DanoCLMMState.model_validate(values)
+
+
+def test_net_reingest_preserves_reserves() -> None:
+    """STEEL-273 gate: net re-ingest must NOT re-subtract the carve."""
+    # zero_reserve has a real non-zero carve (platform_fee_x = 442_697_938).
+    p = _pool("zero_reserve")
+    rt = _net_reingest(p)
+    assert rt.reserve_a == p.reserve_a
+    assert rt.reserve_b == p.reserve_b
+    assert rt.virtual_reserves() == p.virtual_reserves()
+
+
+def test_net_reingest_is_idempotent() -> None:
+    """Re-ingesting twice is a fixed point (no progressive drift)."""
+    p = _pool("zero_reserve")
+    once = _net_reingest(p)
+    twice = _net_reingest(once)
+    assert twice.reserve_a == p.reserve_a
+    assert twice.reserve_b == p.reserve_b
+
+
+def test_model_dump_roundtrip() -> None:
+    """The native dendrite round-trip is also idempotent for both fixtures."""
+    for key in ("both_reserve", "zero_reserve"):
+        p = _pool(key)
+        rt = DanoCLMMState.model_validate(p.model_dump())
+        assert rt.reserve_a == p.reserve_a
+        assert rt.reserve_b == p.reserve_b
+        assert rt.get_amount_out(Assets(root={p._datum.unit_x: 1_000_000}))[0] == (
+            p.get_amount_out(Assets(root={p._datum.unit_x: 1_000_000}))[0]
+        )
+
+
+# Golden accessor values captured from charli3-dendrite 1.4.8 BEFORE the
+# carve-in-post_init refactor. They must stay byte-identical: the curve and the
+# tx-build asset bag are unchanged; only the internal ``assets`` representation
+# moved from gross to net.
+_GOLDEN = {
+    "both_reserve": {
+        "reserve_a": 100000000,
+        "reserve_b": 13139014,
+        "raw_x": 100000000,
+        "raw_y": 13139014,
+        "al0": [100000000, 13139014],
+        "al1m": [101000000, 13139014],
+        "gao_1m": 98476,
+        "pool_change_1m": [1000000, -98476],
+        "new_pool_assets": {
+            "0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa4e49474854": 13040538,
+            "29d222ce763455e3d7a09a665ce554f00ac89d2e99a1a83d267170c64d494e": 101000000,
+            "d8b69fc53637bcfadbc4469083f706bc293f4d9d2296646c5ca167bb5edd380dd6e1ae5469b984e6624beca0bc329964f7fcc55d5d55a22770198cf2": 1,
+            "lovelace": 4500000,
+        },
+    },
+    "zero_reserve": {
+        "reserve_a": 598968631838,
+        "reserve_b": 0,
+        "raw_x": 599411329776,
+        "raw_y": 16798851,
+        "al0": [598968631838, 0],
+        "al1m": [598969631838, 0],
+        "gao_1m": 0,
+        "pool_change_1m": [1000000, 0],
+        "new_pool_assets": {
+            "0691b2fecca1ac4f53cb6dfb00b7013e561d1f34403b957cbb5af1fa4e49474854": 599412329776,
+            "1f3aec8bfe7ea4fe14c5f121e2a92e301afe414147860d557cac7e345553444378": 16798851,
+            "d8b69fc53637bcfadbc4469083f706bc293f4d9d2296646c5ca167bb24d02ee9fd086a85946189232af0748c2cda616125da11679f1c2ef594966ad2": 1,
+            "lovelace": 42500000,
+        },
+    },
+}
+
+
+def test_carve_byte_identity_with_pre_refactor() -> None:
+    """Every externally-observable value matches pre-refactor 1.4.8 exactly."""
+    for key, g in _GOLDEN.items():
+        p = _pool(key)
+        d = p._datum
+        assert p.reserve_a == g["reserve_a"], key
+        assert p.reserve_b == g["reserve_b"], key
+        assert p.raw_x == g["raw_x"], key
+        assert p.raw_y == g["raw_y"], key
+        assert list(p.active_liquidity(0)) == g["al0"], key
+        assert list(p.active_liquidity(1_000_000)) == g["al1m"], key
+        out, _ = p.get_amount_out(Assets(root={d.unit_x: 1_000_000}))
+        assert out.quantity() == g["gao_1m"], key
+        pcx, pcy = p.compute_pool_change(1_000_000, 0)
+        assert [pcx, pcy] == g["pool_change_1m"], key
+        npa = p._new_pool_assets(pcx, pcy, swap_fee=1_500_000, staking_reward=0)
+        assert dict(npa.root) == g["new_pool_assets"], key


### PR DESCRIPTION
## Problem

`DanoCLMMState` had no `skip_init` and netted the platform-fee/min-ADA carve in the `reserve_a`/`reserve_b` **properties** on every access. A consumer that stores the parsed (net) reserves and reconstructs the pool — a dendrite `model_dump` round-trip, or a downstream net projection (e.g. an indexer's silver tables) — re-applied the carve, **silently double-subtracting**. The curve stayed self-consistent on the wrong reserves, so it was easy to miss (reserves end up `net − carve`, even negative when the carve is large).

## Fix

Align Dano with the existing **VyFi / WingRiders V2** "derive-once, skip-on-reingest" pattern:

- `post_init` subtracts the carve **once**, so `assets` canonically holds the *active* (net) reserves and `reserve_a`/`reserve_b` read them directly.
- `skip_init` keys on the presence of the separate `dex_nft` field — the "already parsed" signal — and skips the subtraction on re-ingest. A fresh chain parse carries the dex NFT *inside* the assets bag (extracted later), so it still takes the full parse path.
- `raw_x`/`raw_y` and a new `_gross_assets()` reconstruct the **gross** UTxO bag for the tx-build path (`swap_utxo`/`_new_pool_assets`), which must preserve the platform fees + min-ADA that stay in the pool output.
- `active_liquidity` is re-expressed in net terms (`(reserve_a + staking_reward, reserve_b)`) — algebraically identical, no gross dependency.

## Byte-identity

Every externally-observable value is **unchanged** vs 1.4.8 — only the internal `assets` representation moved gross→net. Verified against values captured from the released 1.4.8 (`reserve_a/b`, `raw_x/y`, `active_liquidity`, `get_amount_out`, `compute_pool_change`, `_new_pool_assets`), including a real carve>0 pool (`zero_reserve`: `platform_fee_x = 442_697_938`).

## Tests

- `tests/test_dano.py` unchanged + green.
- `tests/test_dano_roundtrip.py` (new): the net-reingest round-trip gate (was RED — `reserve_a` off by `platform_fee_x`, `reserve_b` negative) + a byte-identity guard pinning the pre-refactor values.
- Full pre-commit gate (black / ruff 0.1.6 / mypy) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)