### PR TITLE
feat(splash): derive spot-order beacon for order construction

### DIFF
--- a/src/charli3_dendrite/dexs/amm/splash.py
+++ b/src/charli3_dendrite/dexs/amm/splash.py
@@ -2,10 +2,13 @@
 
 from dataclasses import dataclass
 from dataclasses import field
+from dataclasses import replace
+from hashlib import blake2b
 from typing import Any
 from typing import List
 from typing import Union
 
+import cbor2  # type: ignore[import-not-found]
 from pycardano import Address
 from pycardano import DeserializeException
 from pycardano import PlutusData
@@ -61,6 +64,21 @@ class Rationale(PlutusData):
     denominator: int
 
 
+def _canonical_plutus_cbor(data: PlutusData) -> bytes:
+    """Serialise Plutus data to canonical, definite-length CBOR.
+
+    pycardano encodes Plutus constructors with indefinite-length arrays. The
+    Splash order contract recomputes the order beacon over the canonical
+    (definite-length) encoding of the datum, so any hash that must agree with the
+    on-chain validator has to be taken over this form rather than pycardano's
+    default encoding.
+    """
+    raw = data.to_cbor()
+    if isinstance(raw, str):
+        raw = bytes.fromhex(raw)
+    return cbor2.dumps(cbor2.loads(raw), canonical=True)
+
+
 @dataclass
 class SplashOrderDatum(OrderDatum):
     """Order Datum."""
@@ -98,6 +116,57 @@ class SplashOrderDatum(OrderDatum):
     def order_type(self) -> OrderType:
         """This method should return the type of the order."""
         return OrderType.swap
+
+    def compute_beacon(
+        self,
+        seed_tx_hash: bytes | str,
+        seed_index: int,
+        order_index: int = 0,
+    ) -> bytes:
+        """Derive the 28-byte beacon that binds this order to its funding input.
+
+        The beacon commits to the seed UTxO that funds the order
+        (``seed_tx_hash`` at ``seed_index``), the order's position among the
+        orders created in the same transaction (``order_index``), and the rest of
+        the datum. The on-chain contract reproduces it as::
+
+            blake2b_224(
+                seed_tx_hash
+                + seed_index.to_bytes(8, "big")
+                + order_index.to_bytes(8, "big")
+                + blake2b_224(canonical_cbor(datum with beacon = 28 zero bytes))
+            )
+
+        The inner digest is taken with the ``beacon`` field zeroed and over the
+        canonical CBOR encoding, matching the validator.
+        """
+        if isinstance(seed_tx_hash, str):
+            seed_tx_hash = bytes.fromhex(seed_tx_hash)
+
+        placeholder = replace(self, beacon=bytes(28))
+        inner = blake2b(
+            _canonical_plutus_cbor(placeholder),
+            digest_size=28,
+        ).digest()
+        preimage = (
+            seed_tx_hash
+            + seed_index.to_bytes(8, "big")
+            + order_index.to_bytes(8, "big")
+            + inner
+        )
+        return blake2b(preimage, digest_size=28).digest()
+
+    def with_beacon(
+        self,
+        seed_tx_hash: bytes | str,
+        seed_index: int,
+        order_index: int = 0,
+    ) -> "SplashOrderDatum":
+        """Return a copy of this datum with the ``beacon`` field set correctly."""
+        return replace(
+            self,
+            beacon=self.compute_beacon(seed_tx_hash, seed_index, order_index),
+        )
 
 
 @dataclass

--- a/tests/test_splash_beacon.py
+++ b/tests/test_splash_beacon.py
@@ -1,0 +1,126 @@
+"""Known-answer tests for the Splash spot-order beacon derivation.
+
+The fixtures are taken verbatim from the Splash protocol SDK
+(``protocol-sdk`` ``spotOrderDatum.spec.ts`` and ``spotOrderBeacon.spec.ts``),
+so a passing test means dendrite reproduces the encoding and beacon that the
+on-chain contract expects.
+"""
+
+from charli3_dendrite.dataclasses.datums import AssetClass
+from charli3_dendrite.dataclasses.datums import PlutusFullAddress
+from charli3_dendrite.dexs.amm.splash import Rationale
+from charli3_dendrite.dexs.amm.splash import SplashOrderDatum
+from charli3_dendrite.dexs.amm.splash import _canonical_plutus_cbor
+from pycardano import Address
+from pycardano import Network
+from pycardano import VerificationKeyHash
+
+EXECUTOR = bytes.fromhex(
+    "5cb2c968e5d1c7197a6ce7615967310a375545d9bc65063a964335b2",
+)
+PAYMENT_KH = "74104cd5ca6288c1dd2e22ee5c874fdcfc1b81897462d91153496430"
+STAKE_KH = "de7866fe5068ebf3c87dcdb568da528da5dcb5f659d9b60010e7450f"
+SEED_TX = "02b493cbd8eb40c3d5ed58372949c6d7c48afcf77416cf25189b118f53af19a4"
+EXPECTED_BEACON = "384dc40d3a4361798c5b9eba65245ce972c6b6807034ab51b098d573"
+
+
+def _address() -> Address:
+    return Address(
+        payment_part=VerificationKeyHash(bytes.fromhex(PAYMENT_KH)),
+        staking_part=VerificationKeyHash(bytes.fromhex(STAKE_KH)),
+        network=Network.MAINNET,
+    )
+
+
+def test_spot_order_datum_canonical_cbor():
+    """Canonical CBOR matches the SDK ``spotOrderDatum.spec.ts`` fixture."""
+    datum = SplashOrderDatum(
+        tag=bytes.fromhex("00"),
+        beacon=bytes.fromhex(
+            "73fc8e44a4c04433c4e5870982e7d94867e9be28e501bff03e4ac0cf",
+        ),
+        in_asset=AssetClass(
+            policy=bytes.fromhex(
+                "fb4f75d1ad4eb5c21efd5a32a90c076e63a79daccf25afe4ccd4f714",
+            ),
+            asset_name=bytes.fromhex("24504f50534e454b"),
+        ),
+        tradable_input=998457,
+        cost_per_ex_step=900000,
+        min_marginal_output=249614250,
+        output=AssetClass(policy=b"", asset_name=b""),
+        base_price=Rationale(numerator=1000, denominator=1),
+        fee=0,
+        redeemer_address=PlutusFullAddress.from_address(_address()),
+        cancel_pkh=bytes.fromhex(PAYMENT_KH),
+        permitted_executors=[EXECUTOR],
+    )
+
+    expected = (
+        "d8798c4100581c73fc8e44a4c04433c4e5870982e7d94867e9be28e501bff03e4ac0cf"
+        "d87982581cfb4f75d1ad4eb5c21efd5a32a90c076e63a79daccf25afe4ccd4f714"
+        "4824504f50534e454b1a000f3c391a000dbba01a0ee0cfaad879824040"
+        "d879821903e80100d87982d87981581c74104cd5ca6288c1dd2e22ee5c874fdc"
+        "fc1b81897462d91153496430d87981d87981d87981581cde7866fe5068ebf3c8"
+        "7dcdb568da528da5dcb5f659d9b60010e7450f581c74104cd5ca6288c1dd2e22"
+        "ee5c874fdcfc1b81897462d9115349643081581c5cb2c968e5d1c7197a6ce761"
+        "5967310a375545d9bc65063a964335b2"
+    )
+
+    assert _canonical_plutus_cbor(datum).hex() == expected
+
+
+def _beacon_fixture_datum() -> SplashOrderDatum:
+    return SplashOrderDatum(
+        tag=bytes.fromhex("00"),
+        beacon=bytes(28),
+        in_asset=AssetClass(policy=b"", asset_name=b""),
+        tradable_input=1000000,
+        cost_per_ex_step=900000,
+        min_marginal_output=138502,
+        output=AssetClass(
+            policy=bytes.fromhex(
+                "cebbd6a8ca954b7fc7a346d0baed4182e0358059f38065de279fb822",
+            ),
+            asset_name=bytes.fromhex("43617264616e6f20436174"),
+        ),
+        base_price=Rationale(
+            numerator=13850243829651554,
+            denominator=100000000000000000,
+        ),
+        fee=0,
+        redeemer_address=PlutusFullAddress.from_address(_address()),
+        cancel_pkh=bytes.fromhex(PAYMENT_KH),
+        permitted_executors=[EXECUTOR],
+    )
+
+
+def test_compute_beacon():
+    """Beacon matches the SDK ``spotOrderBeacon.spec.ts`` fixture."""
+    beacon = _beacon_fixture_datum().compute_beacon(
+        SEED_TX,
+        seed_index=1,
+        order_index=0,
+    )
+
+    assert beacon.hex() == EXPECTED_BEACON
+
+
+def test_compute_beacon_accepts_bytes_tx_hash():
+    """A bytes seed tx hash gives the same result as the hex form."""
+    datum = _beacon_fixture_datum()
+
+    assert datum.compute_beacon(SEED_TX, 1, 0) == datum.compute_beacon(
+        bytes.fromhex(SEED_TX),
+        1,
+        0,
+    )
+
+
+def test_with_beacon_is_idempotent():
+    """``with_beacon`` zeroes the field internally, so re-stamping is stable."""
+    stamped = _beacon_fixture_datum().with_beacon(SEED_TX, 1, 0)
+
+    assert stamped.beacon.hex() == EXPECTED_BEACON
+    # recomputing on the already-stamped datum yields the same beacon
+    assert stamped.with_beacon(SEED_TX, 1, 0).beacon == stamped.beacon


### PR DESCRIPTION
## Summary

Splash spot/limit orders carry a 28-byte `beacon` in their datum that binds the order to its funding input. Until now dendrite could parse the field but not reproduce it, so it could not construct valid Splash orders.

This adds the derivation:

```
beacon = blake2b_224(
      seed_tx_hash                       # 32 bytes — the UTxO that funds the order
    + seed_index.to_bytes(8, "big")
    + order_index.to_bytes(8, "big")     # order's position among orders in the tx
    + blake2b_224(canonical_cbor(datum with beacon = 28 zero bytes))
)
```

The inner digest is taken over **canonical, definite-length CBOR**. pycardano serialises Plutus constructors with indefinite-length arrays, so a canonical re-encoding step is required for the hash to match what the on-chain contract computes.

## Changes

- `_canonical_plutus_cbor()` — serialise Plutus data to canonical definite-length CBOR.
- `SplashOrderDatum.compute_beacon(seed_tx_hash, seed_index, order_index=0)` — derive the beacon.
- `SplashOrderDatum.with_beacon(...)` — return a copy of the datum with the beacon stamped in.

## Tests

`tests/test_splash_beacon.py` — known-answer tests reproducing the Splash protocol SDK fixtures byte-for-byte:
- canonical datum CBOR (`spotOrderDatum.spec.ts`)
- beacon (`spotOrderBeacon.spec.ts`)
- hex/bytes tx-hash equivalence and `with_beacon` idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)