### PR TITLE
fix(cardano-swaps): fund a min-ADA carrier on ADA-offer create

### DIFF
--- a/src/charli3_dendrite/dexs/ob/cardanoswaps.py
+++ b/src/charli3_dendrite/dexs/ob/cardanoswaps.py
@@ -585,10 +585,33 @@ class CardanoSwapsOrderState(AbstractOrderState):
             amount=asset_to_value(output_assets),
             datum=datum,
         )
-        txo.amount.coin = max(
-            txo.amount.coin,
-            min_lovelace(tx_builder.context, output=txo),
-        )
+        if offer_unit == "lovelace":
+            # ADA offer: the offered asset IS the UTxO's min-ADA, and the
+            # validator derives ``offer_taken = lovelace_in - lovelace_out``, so a
+            # taker can never draw the UTxO below its min-ADA floor — the tail of
+            # the stated offer would be un-fillable. Fund a SEPARATE carrier on
+            # top of the offer, sized to the FINAL full-fill state (3 beacons +
+            # the fully-accumulated ask asset + inline datum), so the entire
+            # offer is drawable while the UTxO stays at/above that floor. The
+            # maker reclaims the carrier (plus the accumulated ask) on CLOSE.
+            full_ask = -(-offer.quantity() * num // den)  # ceil(offer x price)
+            final_assets = cls._beacon_mint_assets(datum, 1) + Assets(
+                root={ask_unit: full_ask},
+            )
+            final_txo = TransactionOutput(
+                address=swap_address,
+                amount=asset_to_value(final_assets),
+                datum=datum,
+            )
+            carrier = min_lovelace(tx_builder.context, output=final_txo)
+            txo.amount.coin = offer.quantity() + carrier
+        else:
+            # Token offer: the offered token fully leaves on a fill and the
+            # min-ADA is a separate lovelace carrier (no phantom tail).
+            txo.amount.coin = max(
+                txo.amount.coin,
+                min_lovelace(tx_builder.context, output=txo),
+            )
         tx_builder.add_output(txo)
 
         return txo, datum

--- a/tests/test_cardanoswaps.py
+++ b/tests/test_cardanoswaps.py
@@ -27,6 +27,7 @@ from pycardano import Value
 from pycardano import VerificationKeyHash
 from pycardano import plutus_script_hash
 from pycardano.backend.base import ChainContext
+from pycardano.utils import min_lovelace
 
 from charli3_dendrite.dataclasses.datums import PlutusNone
 from charli3_dendrite.dataclasses.models import Assets
@@ -48,6 +49,7 @@ from charli3_dendrite.dexs.ob.cardanoswaps import ask_beacon_name
 from charli3_dendrite.dexs.ob.cardanoswaps import offer_beacon_name
 from charli3_dendrite.dexs.ob.cardanoswaps import pair_beacon_name
 from charli3_dendrite.utility import apply_params_to_script
+from charli3_dendrite.utility import asset_to_value
 
 # --- synthetic on-chain values --------------------------------------------
 
@@ -644,6 +646,44 @@ def test_build_create_mints_three_beacons_and_datum(tx_builder) -> None:
     assert txo.datum == datum
     assert _output_units(txo) == set(mint)  # the 3 beacons (offer is ADA)
     assert txo in tx_builder.outputs
+
+
+def test_build_create_ada_offer_funds_drawable_carrier(tx_builder) -> None:
+    """An ADA-offer CREATE funds offer + a carrier sized to the FINAL full-fill
+    state (3 beacons + fully-accumulated ask + datum), so the ENTIRE offered ADA
+    is drawable — no phantom, un-fillable min-ADA tail.
+
+    The validator derives ``offer_taken = lovelace_in - lovelace_out``, so the
+    resting UTxO can never be drawn below its (ask-laden) min-ADA floor; funding
+    that floor as a separate carrier on top of the offer makes the full offer
+    takeable.
+    """
+    offer_qty = 10_000_000
+    num, den = 2, 1
+    txo, datum = CardanoSwapsOrderState.build_create(
+        owner_address=OWNER,
+        offer=Assets(root={"lovelace": offer_qty}),
+        ask=Assets(root={TOKEN_A_UNIT: 0}),
+        price=(num, den),
+        tx_builder=tx_builder,
+    )
+
+    # Independently size the floor the continuation must hold at a FULL fill:
+    # 3 beacons + the fully-accumulated ask (offer × price) + the inline datum.
+    full_ask = -(-offer_qty * num // den)
+    final_assets = CardanoSwapsOrderState._beacon_mint_assets(datum, 1) + Assets(
+        root={TOKEN_A_UNIT: full_ask},
+    )
+    final_txo = TransactionOutput(
+        address=txo.address,
+        amount=asset_to_value(final_assets),
+        datum=datum,
+    )
+    carrier = min_lovelace(tx_builder.context, output=final_txo)
+
+    # Resting UTxO holds exactly offer + carrier; the whole offer is drawable.
+    assert txo.amount.coin == offer_qty + carrier
+    assert txo.amount.coin - carrier == offer_qty
 
 
 def test_build_create_expiration_set(tx_builder) -> None:


### PR DESCRIPTION
## Problem

For a one-way **ADA-offer** swap, `build_create` funds the resting UTxO with only the offered lovelace (bumped to min-ADA). Because the offered asset *is* lovelace and the swap validator derives `offer_taken = lovelace_in - lovelace_out`, a taker can never draw the UTxO below its min-ADA floor (3 beacons + accumulated ask + inline datum) — so the tail of the stated offer (~min-ADA) is structurally **un-fillable / phantom**.

Token-offer swaps don't have this: the offered token fully leaves and the min-ADA is a separate lovelace carrier.

## Fix

When the offer asset is lovelace, fund a **separate carrier on top of the offer**, sized to the **final full-fill state** — the UTxO holding the 3 beacons + the fully-accumulated ask asset (`offer × price`) + the inline datum. The entire offer is then drawable while the UTxO never drops below that (ask-laden) min-ADA floor; the maker funds the carrier and reclaims it (plus the accumulated ask) on close. The token-offer path is unchanged.

## Tests

Adds `test_build_create_ada_offer_funds_drawable_carrier` (offline context): asserts the resting coin equals `offer + carrier`, where the carrier is the independently-computed final-state `min_lovelace`. All CardanoSwaps tests pass; `build_create`, `swap_utxo`, and `build_close` paths unchanged for token offers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)