### PR TITLE
Fix extraneous datum in Cardano-Swaps build_close/swap_utxo (rejected on submit)

### DIFF
--- a/src/charli3_dendrite/dexs/ob/cardanoswaps.py
+++ b/src/charli3_dendrite/dexs/ob/cardanoswaps.py
@@ -702,7 +702,10 @@ class CardanoSwapsOrderState(AbstractOrderState):
             script=self._swap_script_arg(swap_ref_utxo),
             redeemer=Redeemer(Swap()),
         )
-        tx_builder.datums.update({self.order_datum.hash(): self.order_datum})
+        # No witness datum: the order UTxO carries its SwapDatum inline (CS requires
+        # inline datums, and ``_input_utxo`` attaches it to the spent input above), so
+        # the validator reads it from the input directly. Adding the same datum to the
+        # witness set makes it an extraneous datum the ledger rejects on submit.
 
         # The swap is a single accumulating UTxO: the taker removes the offer
         # they take and deposits the ask (at price or better) back into the SAME
@@ -780,7 +783,10 @@ class CardanoSwapsOrderState(AbstractOrderState):
             script=self._swap_script_arg(swap_ref_utxo),
             redeemer=Redeemer(SpendWithMint()),
         )
-        tx_builder.datums.update({self.order_datum.hash(): self.order_datum})
+        # No witness datum: the order UTxO carries its SwapDatum inline (CS requires
+        # inline datums, and ``_input_utxo`` attaches it to the spent input above), so
+        # the validator reads it from the input directly. Adding the same datum to the
+        # witness set makes it an extraneous datum the ledger rejects on submit.
 
         # Burn the three beacons.
         tx_builder.add_minting_script(


### PR DESCRIPTION
## Problem

A one-way swap order UTxO carries its `SwapDatum` **inline** (the beacon policy validator requires inline datums), and `CardanoSwapsOrderState._input_utxo` correctly attaches that inline datum to the spent input. But both `build_close` and `swap_utxo` then *also* did:

```python
tx_builder.datums.update({self.order_datum.hash(): self.order_datum})
```

…adding the same datum to the **witness set**. The datum is now present twice — inline on the input (where the validator reads it) and redundantly in the witnesses.

The ledger rejects the witness copy as an **extraneous datum** (Ogmios `submitTransaction` error **3112** — "contains datums not associated with any script or output"), so the transaction fails on submit. `evaluateTransaction` does not enforce this rule, so the problem is invisible until a real submission.

## Fix

Drop the redundant `tx_builder.datums.update(...)` in both `build_close` and `swap_utxo`. The inline datum on the spent input (via `_input_utxo`) is all the validator needs.

## Verification

Rebuilding a CLOSE through `build_close` after the change attaches **zero** witness datums, while the spent order UTxO still carries its datum inline — so the script executes against the inline datum and the ledger no longer sees an extraneous datum. (No CS build tests exist in the suite to regress; the change is a pure removal of the duplicate witness datum.)