### PR TITLE
fix(cardano-swaps): use a fixed ADA-offer deposit for a predictable carve-out

### DIFF
--- a/src/charli3_dendrite/dexs/ob/cardanoswaps.py
+++ b/src/charli3_dendrite/dexs/ob/cardanoswaps.py
@@ -14,6 +14,7 @@ are implemented separately.
 import hashlib
 import time
 from dataclasses import dataclass
+from typing import ClassVar
 from typing import Union
 
 from pycardano import Address
@@ -262,6 +263,14 @@ class CardanoSwapsOrderState(AbstractOrderState):
     datum_hash: str
     inactive: bool = False
     fee: int = 0
+
+    # Fixed ADA deposit carved into an ADA-offer swap UTxO on CREATE, on top of
+    # the offer, so the FULL offer is drawable (the deposit — not the offer —
+    # satisfies the continuation's min-ADA floor) and the carved amount is a known
+    # constant downstream readers can net out of the displayed offer. 3 ADA sits
+    # comfortably above the ~1.5-2 ADA min-UTxO of a CS swap output (3 beacons +
+    # the accumulated ask). The maker reclaims it (plus the accumulated ask) on CLOSE.
+    ADA_OFFER_DEPOSIT: ClassVar[int] = 3_000_000
 
     _batcher: Assets = Assets(lovelace=0)
     _datum_parsed: PlutusData | None = None
@@ -589,22 +598,14 @@ class CardanoSwapsOrderState(AbstractOrderState):
             # ADA offer: the offered asset IS the UTxO's min-ADA, and the
             # validator derives ``offer_taken = lovelace_in - lovelace_out``, so a
             # taker can never draw the UTxO below its min-ADA floor — the tail of
-            # the stated offer would be un-fillable. Fund a SEPARATE carrier on
-            # top of the offer, sized to the FINAL full-fill state (3 beacons +
-            # the fully-accumulated ask asset + inline datum), so the entire
-            # offer is drawable while the UTxO stays at/above that floor. The
-            # maker reclaims the carrier (plus the accumulated ask) on CLOSE.
-            full_ask = -(-offer.quantity() * num // den)  # ceil(offer x price)
-            final_assets = cls._beacon_mint_assets(datum, 1) + Assets(
-                root={ask_unit: full_ask},
-            )
-            final_txo = TransactionOutput(
-                address=swap_address,
-                amount=asset_to_value(final_assets),
-                datum=datum,
-            )
-            carrier = min_lovelace(tx_builder.context, output=final_txo)
-            txo.amount.coin = offer.quantity() + carrier
+            # the stated offer would be un-fillable. Fund a SEPARATE, FIXED deposit
+            # (:attr:`ADA_OFFER_DEPOSIT`) on top of the offer, sized comfortably
+            # above the final full-fill floor (3 beacons + the accumulated ask +
+            # datum), so the entire offer is drawable while the UTxO stays above
+            # that floor — and the carved-out amount is a known constant a reader
+            # can net out of the displayed offer. The maker reclaims the deposit
+            # (plus the accumulated ask) on CLOSE.
+            txo.amount.coin = offer.quantity() + cls.ADA_OFFER_DEPOSIT
         else:
             # Token offer: the offered token fully leaves on a fill and the
             # min-ADA is a separate lovelace carrier (no phantom tail).

--- a/tests/test_cardanoswaps.py
+++ b/tests/test_cardanoswaps.py
@@ -648,15 +648,15 @@ def test_build_create_mints_three_beacons_and_datum(tx_builder) -> None:
     assert txo in tx_builder.outputs
 
 
-def test_build_create_ada_offer_funds_drawable_carrier(tx_builder) -> None:
-    """An ADA-offer CREATE funds offer + a carrier sized to the FINAL full-fill
-    state (3 beacons + fully-accumulated ask + datum), so the ENTIRE offered ADA
-    is drawable — no phantom, un-fillable min-ADA tail.
+def test_build_create_ada_offer_funds_fixed_deposit(tx_builder) -> None:
+    """An ADA-offer CREATE funds offer + a FIXED deposit (``ADA_OFFER_DEPOSIT``),
+    so the ENTIRE offered ADA is drawable AND the deposit is a known constant
+    downstream indexers can net out of the displayed offer.
 
     The validator derives ``offer_taken = lovelace_in - lovelace_out``, so the
-    resting UTxO can never be drawn below its (ask-laden) min-ADA floor; funding
-    that floor as a separate carrier on top of the offer makes the full offer
-    takeable.
+    resting UTxO can never be drawn below its (ask-laden) min-ADA floor; funding a
+    fixed deposit on top of the offer — comfortably above that floor — makes the
+    full offer takeable while keeping the carved-out amount predictable.
     """
     offer_qty = 10_000_000
     num, den = 2, 1
@@ -668,8 +668,16 @@ def test_build_create_ada_offer_funds_drawable_carrier(tx_builder) -> None:
         tx_builder=tx_builder,
     )
 
-    # Independently size the floor the continuation must hold at a FULL fill:
-    # 3 beacons + the fully-accumulated ask (offer × price) + the inline datum.
+    deposit = CardanoSwapsOrderState.ADA_OFFER_DEPOSIT
+    # Resting UTxO holds exactly offer + the fixed deposit; the whole offer is
+    # drawable (the deposit, not the offer, satisfies the continuation floor).
+    assert txo.amount.coin == offer_qty + deposit
+    assert txo.amount.coin - deposit == offer_qty
+
+    # Guard: the fixed deposit must still cover the FINAL full-fill min-ADA floor
+    # (3 beacons + fully-accumulated ask + datum), else the offer tail would be
+    # un-fillable. If a future protocol-param change pushes the floor above the
+    # constant, this fails loudly.
     full_ask = -(-offer_qty * num // den)
     final_assets = CardanoSwapsOrderState._beacon_mint_assets(datum, 1) + Assets(
         root={TOKEN_A_UNIT: full_ask},
@@ -679,11 +687,7 @@ def test_build_create_ada_offer_funds_drawable_carrier(tx_builder) -> None:
         amount=asset_to_value(final_assets),
         datum=datum,
     )
-    carrier = min_lovelace(tx_builder.context, output=final_txo)
-
-    # Resting UTxO holds exactly offer + carrier; the whole offer is drawable.
-    assert txo.amount.coin == offer_qty + carrier
-    assert txo.amount.coin - carrier == offer_qty
+    assert deposit >= min_lovelace(tx_builder.context, output=final_txo)
 
 
 def test_build_create_expiration_set(tx_builder) -> None:


### PR DESCRIPTION
## Summary
ADA-offer one-way swaps fund a min-ADA carrier on top of the offer so the full offer stays drawable (the validator derives `offer_taken = lovelace_in - lovelace_out`, so a taker can never draw the UTxO below its min-ADA floor). That carrier was sized to the computed `min_lovelace` of the final full-fill state, which makes the carved-out (non-offer) lovelace vary per order and awkward for a consumer to net out of the displayed offer.

This replaces the computed carrier with a fixed `ADA_OFFER_DEPOSIT` (3 ADA) that sits comfortably above that floor for a CS swap UTxO (3 beacons + the accumulated ask). The full offer remains drawable, and the carved-out amount is a known constant a consumer can subtract.

## Changes
- Add `CardanoSwapsOrderState.ADA_OFFER_DEPOSIT: ClassVar[int] = 3_000_000`.
- `build_create` ADA-offer branch funds `offer.quantity() + ADA_OFFER_DEPOSIT` (was the computed `min_lovelace` carrier).
- Test asserts the fixed deposit and guards that it still covers the final full-fill `min_lovelace` floor, so the whole offer stays drawable.

## Test
`pytest tests/test_cardanoswaps.py` — 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
