### PR TITLE
Revert fixed ADA-offer deposit; restore per-order computed carrier

### DIFF
--- a/src/charli3_dendrite/dexs/ob/cardanoswaps.py
+++ b/src/charli3_dendrite/dexs/ob/cardanoswaps.py
@@ -14,7 +14,6 @@ are implemented separately.
 import hashlib
 import time
 from dataclasses import dataclass
-from typing import ClassVar
 from typing import Union
 
 from pycardano import Address
@@ -263,14 +262,6 @@ class CardanoSwapsOrderState(AbstractOrderState):
     datum_hash: str
     inactive: bool = False
     fee: int = 0
-
-    # Fixed ADA deposit carved into an ADA-offer swap UTxO on CREATE, on top of
-    # the offer, so the FULL offer is drawable (the deposit — not the offer —
-    # satisfies the continuation's min-ADA floor) and the carved amount is a known
-    # constant downstream readers can net out of the displayed offer. 3 ADA sits
-    # comfortably above the ~1.5-2 ADA min-UTxO of a CS swap output (3 beacons +
-    # the accumulated ask). The maker reclaims it (plus the accumulated ask) on CLOSE.
-    ADA_OFFER_DEPOSIT: ClassVar[int] = 3_000_000
 
     _batcher: Assets = Assets(lovelace=0)
     _datum_parsed: PlutusData | None = None
@@ -598,14 +589,22 @@ class CardanoSwapsOrderState(AbstractOrderState):
             # ADA offer: the offered asset IS the UTxO's min-ADA, and the
             # validator derives ``offer_taken = lovelace_in - lovelace_out``, so a
             # taker can never draw the UTxO below its min-ADA floor — the tail of
-            # the stated offer would be un-fillable. Fund a SEPARATE, FIXED deposit
-            # (:attr:`ADA_OFFER_DEPOSIT`) on top of the offer, sized comfortably
-            # above the final full-fill floor (3 beacons + the accumulated ask +
-            # datum), so the entire offer is drawable while the UTxO stays above
-            # that floor — and the carved-out amount is a known constant a reader
-            # can net out of the displayed offer. The maker reclaims the deposit
-            # (plus the accumulated ask) on CLOSE.
-            txo.amount.coin = offer.quantity() + cls.ADA_OFFER_DEPOSIT
+            # the stated offer would be un-fillable. Fund a SEPARATE carrier on
+            # top of the offer, sized to the FINAL full-fill state (3 beacons +
+            # the fully-accumulated ask asset + inline datum), so the entire
+            # offer is drawable while the UTxO stays at/above that floor. The
+            # maker reclaims the carrier (plus the accumulated ask) on CLOSE.
+            full_ask = -(-offer.quantity() * num // den)  # ceil(offer x price)
+            final_assets = cls._beacon_mint_assets(datum, 1) + Assets(
+                root={ask_unit: full_ask},
+            )
+            final_txo = TransactionOutput(
+                address=swap_address,
+                amount=asset_to_value(final_assets),
+                datum=datum,
+            )
+            carrier = min_lovelace(tx_builder.context, output=final_txo)
+            txo.amount.coin = offer.quantity() + carrier
         else:
             # Token offer: the offered token fully leaves on a fill and the
             # min-ADA is a separate lovelace carrier (no phantom tail).

--- a/tests/test_cardanoswaps.py
+++ b/tests/test_cardanoswaps.py
@@ -648,15 +648,15 @@ def test_build_create_mints_three_beacons_and_datum(tx_builder) -> None:
     assert txo in tx_builder.outputs
 
 
-def test_build_create_ada_offer_funds_fixed_deposit(tx_builder) -> None:
-    """An ADA-offer CREATE funds offer + a FIXED deposit (``ADA_OFFER_DEPOSIT``),
-    so the ENTIRE offered ADA is drawable AND the deposit is a known constant
-    downstream indexers can net out of the displayed offer.
+def test_build_create_ada_offer_funds_drawable_carrier(tx_builder) -> None:
+    """An ADA-offer CREATE funds offer + a carrier sized to the FINAL full-fill
+    state (3 beacons + fully-accumulated ask + datum), so the ENTIRE offered ADA
+    is drawable — no phantom, un-fillable min-ADA tail.
 
     The validator derives ``offer_taken = lovelace_in - lovelace_out``, so the
-    resting UTxO can never be drawn below its (ask-laden) min-ADA floor; funding a
-    fixed deposit on top of the offer — comfortably above that floor — makes the
-    full offer takeable while keeping the carved-out amount predictable.
+    resting UTxO can never be drawn below its (ask-laden) min-ADA floor; funding
+    that floor as a separate carrier on top of the offer makes the full offer
+    takeable.
     """
     offer_qty = 10_000_000
     num, den = 2, 1
@@ -668,16 +668,8 @@ def test_build_create_ada_offer_funds_fixed_deposit(tx_builder) -> None:
         tx_builder=tx_builder,
     )
 
-    deposit = CardanoSwapsOrderState.ADA_OFFER_DEPOSIT
-    # Resting UTxO holds exactly offer + the fixed deposit; the whole offer is
-    # drawable (the deposit, not the offer, satisfies the continuation floor).
-    assert txo.amount.coin == offer_qty + deposit
-    assert txo.amount.coin - deposit == offer_qty
-
-    # Guard: the fixed deposit must still cover the FINAL full-fill min-ADA floor
-    # (3 beacons + fully-accumulated ask + datum), else the offer tail would be
-    # un-fillable. If a future protocol-param change pushes the floor above the
-    # constant, this fails loudly.
+    # Independently size the floor the continuation must hold at a FULL fill:
+    # 3 beacons + the fully-accumulated ask (offer × price) + the inline datum.
     full_ask = -(-offer_qty * num // den)
     final_assets = CardanoSwapsOrderState._beacon_mint_assets(datum, 1) + Assets(
         root={TOKEN_A_UNIT: full_ask},
@@ -687,7 +679,11 @@ def test_build_create_ada_offer_funds_fixed_deposit(tx_builder) -> None:
         amount=asset_to_value(final_assets),
         datum=datum,
     )
-    assert deposit >= min_lovelace(tx_builder.context, output=final_txo)
+    carrier = min_lovelace(tx_builder.context, output=final_txo)
+
+    # Resting UTxO holds exactly offer + carrier; the whole offer is drawable.
+    assert txo.amount.coin == offer_qty + carrier
+    assert txo.amount.coin - carrier == offer_qty
 
 
 def test_build_create_expiration_set(tx_builder) -> None:


### PR DESCRIPTION
## Summary
Reverts #190 (the fixed 3-ADA `ADA_OFFER_DEPOSIT` for ADA-offer swaps) and restores the per-order **computed** min-UTxO carrier.

The fixed constant is brittle. A Cardano-Swaps order UTxO's real min-UTxO floor — 3 beacons + the inline `SwapDatum` + the accumulated ask — is **~2.65 ADA and varies per order**. A hardcoded 3 ADA therefore both *over*-deposits (locking more than needed) and, for any order whose floor exceeds it (larger datum / bigger accumulated ask), *under*-deposits — leaving an unfillable offer tail.

Restoring `carrier = min_lovelace(final_txo)` (the full-fill state: 3 beacons + the fully-accumulated ask + datum) sizes the deposit correctly for every order, so the entire offer stays drawable while the UTxO holds exactly its floor. This is the behavior prior to #190.

## Changes
- Revert the ADA-offer branch of `build_create` to the computed `min_lovelace` carrier.
- Remove the `ADA_OFFER_DEPOSIT` class constant (and the now-unused `ClassVar` import).
- Restore the carrier test.

## Test
`pytest tests/test_cardanoswaps.py` — 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
