### PR TITLE
fix(cancel): owner-reclaim redeemer for Splash orders + PlutusV2 for Minswap stable orders

### DIFF
--- a/src/charli3_dendrite/dexs/amm/minswap.py
+++ b/src/charli3_dendrite/dexs/amm/minswap.py
@@ -1140,6 +1140,14 @@ class MinswapDJEDiUSDStableState(AbstractCommonStableSwapPoolState, MinswapCPPSt
     def order_datum_class(cls) -> type[MinswapStableOrderDatum]:
         return MinswapStableOrderDatum
 
+    @classmethod
+    def default_script_class(cls) -> type[PlutusV1Script] | type[PlutusV2Script]:
+        return PlutusV2Script
+
+    @classmethod
+    def script_class(self) -> type[PlutusV2Script]:
+        return PlutusV2Script
+
     def get_amount_out(
         self,
         asset: Assets,

--- a/src/charli3_dendrite/dexs/amm/splash.py
+++ b/src/charli3_dendrite/dexs/amm/splash.py
@@ -335,6 +335,18 @@ class CPPoolRedeemer(PlutusData):
                 self.self_index = key.index
 
 
+@dataclass
+class SplashCancelRedeemer(PlutusData):
+    """Owner-reclaim redeemer for a Splash order spend (constructor 0).
+
+    The base ``cancel_redeemer`` emits the executor action (constructor 1); an
+    owner cancelling their own order spends with the owner-reclaim action
+    (constructor 0).
+    """
+
+    CONSTR_ID = 0
+
+
 class SplashBaseState(AbstractPairState):
     """Base state class for Splash DEX pools."""
 
@@ -379,6 +391,15 @@ class SplashBaseState(AbstractPairState):
     def script_class(cls) -> type[PlutusV2Script]:
         """Return the script class for this DEX."""
         return PlutusV2Script
+
+    @classmethod
+    def cancel_redeemer(cls) -> Redeemer:
+        """Return the owner-reclaim redeemer for a Splash order spend.
+
+        Overrides the base executor action (constructor 1) with the owner-reclaim
+        action (constructor 0) used when the order owner cancels their own order.
+        """
+        return Redeemer(SplashCancelRedeemer())
 
     @classmethod
     def extract_pool_nft(cls, values: dict[str, Any]) -> Assets | None:


### PR DESCRIPTION
Two order-cancel correctness fixes for spending an order UTxO as its owner.

## Splash owner-reclaim redeemer

`SplashBaseState.cancel_redeemer` inherited the base executor action (constructor 1).
When an order **owner** cancels their own order on-chain they spend with the
owner-reclaim action (**constructor 0**); the executor action is signed by the
permitted executor, so a cancel built with the owner's signature and the inherited
redeemer fails phase-2 validation. This adds a `SplashCancelRedeemer` (constructor 0)
and overrides `cancel_redeemer` on `SplashBaseState`. The constructor mapping is
established from on-chain spends of the Splash order script (owner spends use
constructor 0; executor spends use constructor 1).

## Minswap stable-swap order script version

The six Minswap stable-swap order classes (via `MinswapDJEDiUSDStableState`) inherited
`default_script_class = PlutusV1Script`, but the on-chain stable-swap **order** script
is `PlutusV2` — wrapping the fetched script bytes as V1 produces a script-hash
mismatch. This overrides `default_script_class` / `script_class` to `PlutusV2Script`,
mirroring `MinswapV2CPPState`.

Both verified by building and evaluating real owner-cancel transactions (Ogmios
`evaluateTransaction`, build-not-submit) for the affected order classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
