### PR TITLE
feat(saturnswap): export SaturnSwapV3OrderState from the package top level

### DIFF
--- a/src/charli3_dendrite/__init__.py
+++ b/src/charli3_dendrite/__init__.py
@@ -34,6 +34,7 @@ from charli3_dendrite.dexs.ob.geniusyield import GeniusYieldOrderState
 from charli3_dendrite.dexs.ob.saturnswap import SaturnSwapLegacyOrderState
 from charli3_dendrite.dexs.ob.saturnswap import SaturnSwapOrderBook
 from charli3_dendrite.dexs.ob.saturnswap import SaturnSwapOrderState
+from charli3_dendrite.dexs.ob.saturnswap import SaturnSwapV3OrderState
 from charli3_dendrite.utility import Assets
 
 # from charli3_dendrite.dexs.ob.axo import AxoOBMarketState  # noqa: ERA001

--- a/src/charli3_dendrite/dexs/ob/saturnswap.py
+++ b/src/charli3_dendrite/dexs/ob/saturnswap.py
@@ -1110,7 +1110,7 @@ class SaturnSwapOrderBook(AbstractOrderBookState):
     """SaturnSwap order book aggregating individual orders.
 
     Aggregates orders from every contract version in
-    :data:`_SATURNSWAP_ORDER_STATE_CLASSES` (live 1% + legacy 4%).
+    :data:`_SATURNSWAP_ORDER_STATE_CLASSES` (V3 1%, live 1%, legacy 4%).
     """
 
     _deposit: Assets = Assets(lovelace=0)
@@ -1124,8 +1124,8 @@ class SaturnSwapOrderBook(AbstractOrderBookState):
         """Build an order book from provided orders or backend UTxOs.
 
         When ``orders`` is not supplied, UTxOs are fetched for every contract
-        version (live 1% + legacy 4%) and validated with the matching order-state
-        class so each order carries the correct taker fee.
+        version (V3 1%, live 1%, legacy 4%) and validated with the matching
+        order-state class so each order carries the correct taker fee.
         """
         min_pair_assets = 2
         utxo_limit = 10_000

--- a/tests/test_saturnswap_v3.py
+++ b/tests/test_saturnswap_v3.py
@@ -195,3 +195,22 @@ def test_v3_relist_carries_coverage_and_floor_forward() -> None:
     assert isinstance(relist.coverage, SaturnSwapSomeCoverage)
     assert relist.coverage.value.premium_bps == covered.coverage.value.premium_bps
     assert relist.min_partial_fill == covered.min_partial_fill
+
+
+def test_v3_order_state_is_top_level_exported() -> None:
+    """SaturnSwapV3OrderState is re-exported from the package top level.
+
+    The V2 + legacy order states and the order book are all importable as
+    ``charli3_dendrite.<name>``; the V3 leaf must be too, so downstream code
+    imports it the same way instead of reaching into the submodule.
+    """
+    import charli3_dendrite
+
+    assert hasattr(
+        charli3_dendrite, "SaturnSwapV3OrderState"
+    ), "SaturnSwapV3OrderState must be re-exported at the package top level"
+    assert charli3_dendrite.SaturnSwapV3OrderState is SaturnSwapV3OrderState
+    # parity with the sibling saturnswap top-level exports
+    assert hasattr(charli3_dendrite, "SaturnSwapOrderState")
+    assert hasattr(charli3_dendrite, "SaturnSwapLegacyOrderState")
+    assert hasattr(charli3_dendrite, "SaturnSwapOrderBook")


### PR DESCRIPTION
`SaturnSwapV3OrderState` is defined and registered at the head of `_SATURNSWAP_ORDER_STATE_CLASSES`, but — unlike `SaturnSwapOrderState`, `SaturnSwapLegacyOrderState`, and `SaturnSwapOrderBook` — it was not re-exported from the package root. Downstream code therefore had to reach into `charli3_dendrite.dexs.ob.saturnswap` to import it.

This adds the top-level import so it's available as `from charli3_dendrite import SaturnSwapV3OrderState`, matching its siblings.

It also refreshes the `SaturnSwapOrderBook` class and `get_book` docstrings, which still described only "live 1% + legacy 4%" and omitted the V3 contract version they already aggregate via `_SATURNSWAP_ORDER_STATE_CLASSES`.

Based on `dev` (1.5.1). Adds one export test; the full SaturnSwap V3 suite (31 tests) is green.
