### PR TITLE
fix(splash): coerce Assets quantities to int + SSPoolRedeemer.set_idx sets pool_in_idx

### DIFF
--- a/src/charli3_dendrite/dataclasses/models.py
+++ b/src/charli3_dendrite/dataclasses/models.py
@@ -108,7 +108,16 @@ def _digest_assets(value: object) -> dict[str, int]:
         root = dict(value)
     else:
         root = dict(value.items())  # type: ignore[attr-defined]
-    return dict(sorted(root.items(), key=lambda x: "" if x[0] == "lovelace" else x[0]))
+    # Coerce quantities to int: the pydantic ``RootModel[dict[str, int]]`` this replaced
+    # validated str/Decimal quantities to int, and callers (e.g. reserves parsed from
+    # JSON/ledger sources) still supply strings. Without this a string quantity survives
+    # into ``asset_to_value`` and yields a non-int Value coin that pycardano rejects.
+    return {
+        k: int(v)
+        for k, v in sorted(
+            root.items(), key=lambda x: "" if x[0] == "lovelace" else x[0],
+        )
+    }
 
 
 class Assets:

--- a/src/charli3_dendrite/dexs/amm/splash.py
+++ b/src/charli3_dendrite/dexs/amm/splash.py
@@ -303,7 +303,7 @@ class SSPoolRedeemer(PlutusData):
         # Set the input index
         for key, value in tx_builder.redeemers().items():
             if value.data == self:
-                self.self_index = key.index
+                self.pool_in_idx = key.index
 
         # Set the output index
         for i, txo in enumerate(tx_builder.outputs):

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -25,6 +25,23 @@ def test_lovelace_first_ordering():
     assert list(a.keys()) == [L, T1, T2]
 
 
+def test_string_quantities_coerced_to_int():
+    # The pydantic RootModel[dict[str, int]] this replaced coerced str/Decimal
+    # quantities to int; callers (reserves parsed from JSON/ledger sources) still supply
+    # strings. A surviving str reaches asset_to_value and yields a non-int Value coin
+    # (pycardano rejects it), so Assets must coerce on construction.
+    from charli3_dendrite.utility import asset_to_value
+
+    a = Assets(root={L: "16145260", T1: "42"})
+    assert a[L] == 16145260 and isinstance(a[L], int)
+    assert a[T1] == 42 and isinstance(a[T1], int)
+    # An int input is unchanged (no regression).
+    assert Assets(root={L: 5_000_000})[L] == 5_000_000
+    # End to end: the resulting Value coin is a real int.
+    coin = asset_to_value(a).coin
+    assert coin == 16145260 and isinstance(coin, int)
+
+
 def test_construction_shapes_agree():
     ref = [(L, 7), (T1, 3)]
     assert list(Assets(root={T1: 3, L: 7}).items()) == ref

--- a/tests/test_splash_redeemers.py
+++ b/tests/test_splash_redeemers.py
@@ -1,0 +1,51 @@
+"""SSPoolRedeemer.set_idx must set ``pool_in_idx`` (not a nonexistent ``self_index``).
+
+The stable-swap redeemer carries ``pool_in_idx``/``pool_out_idx`` (unlike the CPP
+redeemer's ``self_index``); a copy-paste left ``set_idx`` assigning ``self.self_index``,
+so ``pool_in_idx`` stayed 0 and the on-chain redeemer pointed at the wrong input.
+"""
+
+from pycardano import Address, Network, TransactionOutput, VerificationKeyHash
+
+from charli3_dendrite.dexs.amm.splash import SSPoolRedeemer, SwapAction
+
+# The stable-swap pool contract address ``set_idx`` matches the pool output against.
+_POOL_ADDR = "addr1w9wnm7vle7al9q4aw63aw63wxz7aytnpc4h3gcjy0yufxwc3mr3e5"
+
+
+class _Key:
+    def __init__(self, index: int) -> None:
+        self.index = index
+
+
+class _Val:
+    def __init__(self, data: object) -> None:
+        self.data = data
+
+
+class _FakeBuilder:
+    """Minimal ``TransactionBuilder`` stand-in: one redeemer keyed at input index 2."""
+
+    def __init__(self, redeemer: object, outputs: list) -> None:
+        self._redeemers = {_Key(2): _Val(redeemer)}
+        self.outputs = outputs
+
+    def redeemers(self):
+        return self._redeemers
+
+
+def test_ssp_set_idx_sets_pool_in_idx() -> None:
+    red = SSPoolRedeemer(
+        pool_in_idx=0, pool_out_idx=0, action=SwapAction(context_values_list=[0])
+    )
+    non_pool = TransactionOutput(
+        Address(VerificationKeyHash(bytes(28)), network=Network.MAINNET), 2_000_000
+    )
+    pool_out = TransactionOutput(Address.from_primitive(_POOL_ADDR), 2_000_000)
+
+    red.set_idx(_FakeBuilder(red, [non_pool, pool_out]))
+
+    # pool_in_idx comes from the matched redeemer key (was left 0 by the self_index bug).
+    assert red.pool_in_idx == 2
+    # pool_out_idx is the pool output's position (index 1 here).
+    assert red.pool_out_idx == 1


### PR DESCRIPTION
## Summary

Two correctness fixes for the Splash direct-spend path, both surfaced when building/assembling a Splash swap transaction on the plain-`Assets` (1.5.x) code.

### `fix(assets)`: coerce Assets quantities to int on construction
The plain, non-pydantic `Assets` replaced a `RootModel[dict[str, int]]` whose validation coerced `str`/`Decimal` quantities to `int`. `_digest_assets` only normalizes the *shape* of its input, so a string quantity (reserves parsed from JSON/ledger sources still arrive as strings) survives into `asset_to_value` and yields a **non-int pycardano `Value` coin**, which raises when that UTxO is used (e.g. `TypeError: ... Field 'coin' should be of type <class 'int'>, got '16145260'`). Direct-spend pools (Splash) build a pool-input UTxO from reserves via `asset_to_value` and hit it; order-creation pools don't. Fix: `_digest_assets` coerces quantities to `int`, so the mapping is int-valued as its `dict[str, int]` annotation promises.

### `fix(splash)`: `SSPoolRedeemer.set_idx` sets `pool_in_idx`
The stable-swap redeemer carries `pool_in_idx`/`pool_out_idx` (the CPP redeemer has `self_index`); `set_idx` assigned `self.self_index`, so `pool_in_idx` stayed at its default `0` and the on-chain redeemer pointed at input 0 rather than the pool input.

## Tests
- `tests/test_assets.py`: a string-quantity input is coerced to `int` end-to-end through `asset_to_value`; int inputs are unchanged.
- `tests/test_splash_redeemers.py`: `set_idx` sets `pool_in_idx` from the matched redeemer key (and `pool_out_idx` from the pool output).

Both new tests pass; the change is covered by the existing `Assets` construction/arithmetic contract tests.
