### PR TITLE
fix(splash): preserve token/token pool min-UTxO lovelace in swap_utxo

### DIFF
--- a/src/charli3_dendrite/dexs/amm/splash.py
+++ b/src/charli3_dendrite/dexs/amm/splash.py
@@ -367,6 +367,28 @@ class SplashBaseState(AbstractPairState):
         """Return the order selector addresses."""
         return ["addr1w9ryamhgnuz6lau86sqytte2gz5rlktv2yce05e0h3207qssa8euj"]
 
+    def _reinstate_pool_lovelace(
+        self,
+        assets: Assets,
+        pool_utxo_assets: Assets,
+    ) -> None:
+        """Preserve a token/token pool's min-UTxO ADA in the rebuilt pool value.
+
+        When neither reserve is ADA, the pool still holds lovelace as min-UTxO. The
+        reserve-bearing ``self.assets`` carries only the two token reserves (a lovelace
+        key would sort to index 0 and corrupt the positional ``reserve_a``/``reserve_b``
+        indexing), so a value rebuilt from it via ``asset_to_value`` has coin 0 and the
+        builder defaults the recreated pool output to the protocol minimum, dropping the
+        pool's real ADA. The pool validator requires that ADA preserved exactly across a
+        swap (it lies outside the two swapped reserves and is unchanged), so copy the
+        coin from the resolved on-chain pool UTxO into the rebuilt value. For an
+        ADA-paired pool lovelace is a genuine reserve -- carried and updated by the swap
+        -- so this is a no-op.
+        """
+        if self.unit_a == "lovelace" or self.unit_b == "lovelace":
+            return
+        assets.root["lovelace"] = pool_utxo_assets["lovelace"]
+
     @property
     def stake_address(self) -> Address | None:
         """Return the stake address for orders."""
@@ -633,6 +655,7 @@ class SplashSSPState(SplashBaseState, AbstractCommonStableSwapPoolState):
 
         # Create the pool input UTxO
         assets = self.assets + self.pool_nft + self.lp_tokens
+        self._reinstate_pool_lovelace(assets, order_info[0].assets)
         input_utxo = UTxO(
             TransactionInput(
                 transaction_id=TransactionId(bytes.fromhex(self.tx_hash)),
@@ -810,6 +833,7 @@ class SplashCPPState(SplashBaseState, AbstractConstantProductPoolState):
             self.pool_datum.to_cbor(),
         )
         assets = self.assets + self.pool_nft + self.lp_tokens
+        self._reinstate_pool_lovelace(assets, order_info[0].assets)
         assets.root[pool_datum.asset_x.assets.unit()] += pool_datum.treasury_x
         assets.root[pool_datum.asset_y.assets.unit()] += pool_datum.treasury_y
         input_utxo = UTxO(
@@ -995,6 +1019,7 @@ class SplashCPPRoyaltyState(SplashCPPState):
             self.pool_datum.to_cbor(),
         )
         assets = self.assets + self.pool_nft + self.lp_tokens
+        self._reinstate_pool_lovelace(assets, order_info[0].assets)
         assets.root[pool_datum.asset_x.assets.unit()] += (
             pool_datum.treasury_x + self.pool_datum.royalty_x
         )

--- a/tests/test_splash_lovelace.py
+++ b/tests/test_splash_lovelace.py
@@ -1,0 +1,43 @@
+"""Splash swap_utxo preserves a token/token pool's min-UTxO ADA.
+
+A Splash pool whose two reserves are both native tokens still holds lovelace as min-UTxO.
+The reserve-bearing ``self.assets`` carries only the two token reserves (a lovelace key
+would sort to index 0 and corrupt the positional reserve_a/reserve_b indexing), so a pool
+value rebuilt from it drops that ADA -- ``asset_to_value`` emits coin 0 and the builder
+defaults the recreated pool output to min-ADA. The pool validator requires the recreated
+pool output to preserve the pool's lovelace exactly, so ``swap_utxo`` reinstates it from the
+resolved on-chain pool UTxO. For an ADA-paired pool lovelace is a genuine reserve (carried
+and updated by the swap), so the reinstatement is a no-op.
+"""
+
+from charli3_dendrite.dataclasses.models import Assets
+from charli3_dendrite.dexs.amm.splash import SplashBaseState
+
+_T1 = "aa" + "11" * 27  # native-token units (policy+name hex)
+_T2 = "bb" + "22" * 27
+
+
+class _Pool:
+    """Minimal stand-in exposing only what the helper reads: unit_a / unit_b."""
+
+    def __init__(self, unit_a: str, unit_b: str) -> None:
+        self.unit_a = unit_a
+        self.unit_b = unit_b
+
+
+def test_reinstate_lovelace_token_token_pool() -> None:
+    # The rebuilt value has NO lovelace (both reserves are tokens); the on-chain pool UTxO
+    # holds 10 ADA min-UTxO -> it must be reinstated, else the output defaults to min-ADA.
+    rebuilt = Assets(root={_T1: 100, _T2: 200})
+    on_chain = Assets(root={"lovelace": 10_000_000, _T1: 100, _T2: 200})
+    SplashBaseState._reinstate_pool_lovelace(_Pool(_T1, _T2), rebuilt, on_chain)
+    assert rebuilt["lovelace"] == 10_000_000
+
+
+def test_reinstate_lovelace_ada_pool_is_noop() -> None:
+    # ADA-paired pool: lovelace is a real reserve, already carried and swap-updated. The
+    # helper must NOT overwrite it with the (pre-swap) on-chain coin.
+    rebuilt = Assets(root={"lovelace": 55, _T2: 200})
+    on_chain = Assets(root={"lovelace": 10_000_000, _T2: 200})
+    SplashBaseState._reinstate_pool_lovelace(_Pool("lovelace", _T2), rebuilt, on_chain)
+    assert rebuilt["lovelace"] == 55


### PR DESCRIPTION
## Problem

A Splash pool whose two reserves are both native tokens (a token/token pool, no ADA side) still holds ADA as min-UTxO. `swap_utxo` rebuilt the recreated pool output value from `self.assets` — the two token reserves only, which carries no lovelace — so `asset_to_value` emitted `coin=0` and the transaction builder defaulted the recreated pool output to the protocol minimum, dropping the pool's real ADA.

The pool validator runs a check that **only token/token pools execute** (ADA-paired pools skip it): `correctLovelaceToken2TokenValue` requires the recreated pool output's lovelace to equal the input pool's lovelace exactly. With the ADA dropped to min-ADA, a swap through a token/token Splash pool fails on-chain script evaluation.

## Fix

The pool's real lovelace is already fetched at build time but was discarded: `swap_utxo` calls `order_info = get_backend().get_pool_in_tx(...)` and reads only `order_info[0].address`, while `order_info[0].assets` carries the on-chain UTxO's real coin. Reinstate it into the rebuilt value (before `asset_to_value`) in all three `swap_utxo` bodies — `SplashSSPState`, `SplashCPPState` (which `SplashCPPBidirState` inherits), and `SplashCPPRoyaltyState` — via a shared `SplashBaseState._reinstate_pool_lovelace` helper. For an ADA-paired pool lovelace is a genuine reserve (carried and updated by the swap), so the helper is a no-op.

## Testing

- `tests/test_splash_lovelace.py`: token/token pool reinstates the on-chain lovelace; ADA-paired pool is untouched.
- Validated on live mainnet Ogmios (build-not-submit): a transaction spending a token/token Splash pool that holds 10 ADA min-UTxO evaluates clean with the fix and fails (`correctLovelaceToken2TokenValue`) without it; single ADA-paired Splash swaps are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
