### PR TITLE
feat(cardanoswaps): add CardanoSwapsOrderBook aggregate order-book class

### DIFF
--- a/src/charli3_dendrite/__init__.py
+++ b/src/charli3_dendrite/__init__.py
@@ -24,6 +24,7 @@ from charli3_dendrite.dexs.amm.wingriders import WingRidersCPPState
 from charli3_dendrite.dexs.amm.wingriders import WingRidersSSPState
 from charli3_dendrite.dexs.amm.wingriders import WingRidersV2CPPState
 from charli3_dendrite.dexs.amm.wingriders import WingRidersV2SSPState
+from charli3_dendrite.dexs.ob.cardanoswaps import CardanoSwapsOrderBook
 from charli3_dendrite.dexs.ob.cardanoswaps import CardanoSwapsOrderState
 from charli3_dendrite.dexs.ob.chadswap import ChadSwapOrderBook
 from charli3_dendrite.dexs.ob.chadswap import ChadSwapOrderState

--- a/src/charli3_dendrite/dexs/ob/cardanoswaps.py
+++ b/src/charli3_dendrite/dexs/ob/cardanoswaps.py
@@ -14,6 +14,7 @@ are implemented separately.
 import hashlib
 import time
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Union
 
 from pycardano import Address
@@ -30,12 +31,17 @@ from pycardano import UTxO
 from pycardano import plutus_script_hash
 from pycardano.utils import min_lovelace
 
+from charli3_dendrite.backend import get_backend
 from charli3_dendrite.dataclasses.datums import OrderDatum
 from charli3_dendrite.dataclasses.datums import PlutusNone
 from charli3_dendrite.dataclasses.models import Assets
 from charli3_dendrite.dataclasses.models import OrderType
 from charli3_dendrite.dataclasses.models import PoolSelector
+from charli3_dendrite.dexs.ob.ob_base import AbstractOrderBookState
 from charli3_dendrite.dexs.ob.ob_base import AbstractOrderState
+from charli3_dendrite.dexs.ob.ob_base import BuyOrderBook
+from charli3_dendrite.dexs.ob.ob_base import OrderBookOrder
+from charli3_dendrite.dexs.ob.ob_base import SellOrderBook
 from charli3_dendrite.utility import asset_to_value
 
 # v2 one-way beacon minting policy id (also stored verbatim in the datum's
@@ -262,6 +268,13 @@ class CardanoSwapsOrderState(AbstractOrderState):
     datum_hash: str
     inactive: bool = False
     fee: int = 0
+    # The resting UTxO's on-chain address. Unlike every other order-book DEX, a
+    # Cardano-Swaps order carries no owner in its datum — the owner is the resting
+    # address's staking credential (the beacon-tagged swap address = validator
+    # payment part + owner staking part). Retaining it here lets an aggregate fill
+    # (:class:`CardanoSwapsOrderBook`) recover each maker's owner without a separate
+    # lookup; it is populated from the backend UTxO record on ingest.
+    address: str | None = None
 
     _batcher: Assets = Assets(lovelace=0)
     _datum_parsed: PlutusData | None = None
@@ -806,3 +819,183 @@ class CardanoSwapsOrderState(AbstractOrderState):
         # script must be executed (a withdrawal). This builder only assembles the
         # spend + burn; signing/withdrawal is the caller's responsibility.
         return self.order_datum
+
+
+class CardanoSwapsOrderBook(AbstractOrderBookState):
+    """Aggregate order book over resting Cardano-Swaps one-way swap UTxOs.
+
+    The batcher-less, fee-less sibling of the other order-book aggregates: it
+    holds many individual :class:`CardanoSwapsOrderState` orders for a token pair
+    and prices/fills across them. Because a Cardano-Swaps order carries no
+    protocol fee (``fee = 0``), the base level-walk ``get_amount_out`` /
+    ``get_amount_in`` are inherited unchanged; only ``price`` (and construction)
+    diverge, and ``swap_utxo`` folds a fill across the individual orders.
+    """
+
+    fee: int = 0
+    _deposit: Assets = Assets(lovelace=0)
+
+    @classmethod
+    def get_book(
+        cls,
+        assets: Assets,
+        orders: list[CardanoSwapsOrderState] | None = None,
+    ) -> "CardanoSwapsOrderBook":
+        """Build an order book from Cardano-Swaps orders for the given pair.
+
+        Args:
+            assets: The token pair to build the book for (unit(0) + unit(1)).
+            orders: Pre-fetched orders, or None to discover from the backend by
+                beacon policy (``pool_selector`` is beacon-based, not address-based).
+        """
+        if orders is None:
+            selector = CardanoSwapsOrderState.pool_selector()
+            result = get_backend().get_pool_utxos(
+                limit=10000,
+                historical=False,
+                **selector.model_dump(),
+            )
+            orders = [
+                CardanoSwapsOrderState.model_validate(r.model_dump()) for r in result
+            ]
+
+        buy_orders = []
+        sell_orders = []
+        for order in orders:
+            if order.inactive:
+                continue
+            num, denom = order.price
+            o = OrderBookOrder(
+                price=num / denom,
+                quantity=int(order.available.quantity()),
+                state=order,
+            )
+            if order.in_unit == assets.unit() and order.out_unit == assets.unit(1):
+                sell_orders.append(o)
+            elif order.in_unit == assets.unit(1) and order.out_unit == assets.unit(0):
+                buy_orders.append(o)
+
+        return CardanoSwapsOrderBook(
+            assets=assets,
+            plutus_v2=True,
+            block_time=int(time.time()),
+            block_index=0,
+            sell_book_full=SellOrderBook(sell_orders),
+            buy_book_full=BuyOrderBook(buy_orders),
+        )
+
+    @classmethod
+    def dex(cls) -> str:
+        """Official dex name."""
+        return "CardanoSwaps"
+
+    @classmethod
+    def order_selector(cls) -> list[str]:
+        """Order selection: discovery is by beacon policy, not address."""
+        return CardanoSwapsOrderState.order_selector()
+
+    @classmethod
+    def pool_selector(cls) -> PoolSelector:
+        """Pool/order selection: by beacon policy id."""
+        return CardanoSwapsOrderState.pool_selector()
+
+    @classmethod
+    def default_script_class(cls) -> type[PlutusV2Script]:
+        """The swap spending validator is a Plutus V2 script."""
+        return CardanoSwapsOrderState.default_script_class()
+
+    @classmethod
+    def order_datum_class(cls) -> type[PlutusData]:
+        """The PlutusData class for parsing order datums."""
+        return CardanoSwapsOrderState.order_datum_class()
+
+    @property
+    def swap_forward(self) -> bool:
+        """Swap forwarding is supported on the individual orders."""
+        return False
+
+    @property
+    def stake_address(self) -> Address | None:
+        """Batcher-less: no order-book stake address."""
+        return None
+
+    @property
+    def pool_id(self) -> str:
+        """Unique identifier for the Cardano-Swaps order book."""
+        return "CardanoSwaps"
+
+    @property
+    def price(self) -> tuple[Decimal, Decimal]:
+        """Mid price of assets based on the full order books.
+
+        Overridden with an empty-book guard: Cardano-Swaps books are frequently
+        one-sided (all orders offering one direction of the pair), and the base
+        ``price`` dereferences the never-populated optional ``buy_book[0]`` /
+        ``sell_book[0]``.
+        """
+        if not self.buy_book_full or not self.sell_book_full:
+            return Decimal(0), Decimal(0)
+        buy = Decimal(self.buy_book_full[0].price)
+        sell = Decimal(self.sell_book_full[0].price)
+        return (
+            Decimal((buy + (Decimal(1) / sell)) / 2),
+            Decimal((sell + (Decimal(1) / buy)) / 2),
+        )
+
+    def swap_utxo(
+        self,
+        address_source: Address,
+        in_assets: Assets,
+        out_assets: Assets,
+        tx_builder: TransactionBuilder,
+        extra_assets: Assets | None = None,
+        address_target: Address | None = None,
+        datum_target: PlutusData | None = None,
+    ) -> tuple[TransactionOutput | None, PlutusData]:
+        """Build a fill by walking the book, folding one fill per resting order.
+
+        Iterates the appropriate side (sell or buy) best-price-first, filling each
+        resting order via its own ``swap_utxo`` until the input is exhausted. Each
+        fill is threaded the maker's real owner — the resting UTxO's staking
+        credential, carried on the order's ``address`` — so the continuing output
+        lands back at the correct beacon-tagged swap address (defaulting the owner
+        to the taker would reconstruct the wrong input and fail validation).
+        """
+        if in_assets.unit() == self.assets.unit():
+            book = self.sell_book_full
+        else:
+            book = self.buy_book_full
+
+        in_remaining = Assets.model_validate(in_assets.model_dump())
+        txo = None
+        datum = None
+
+        for order in book:
+            state = order.state
+
+            order_out, _ = state.get_amount_out(in_remaining)
+            order_in, _ = state.get_amount_in(order_out)
+
+            # Stop once the remaining budget cannot satisfy a meaningful fill.
+            if order_out.quantity() <= 0 or order_in.quantity() <= 0:
+                break
+
+            if state.address is None:
+                raise ValueError(
+                    "Cardano-Swaps order-book fill requires each resting order's "
+                    "address (the maker's owner staking credential).",
+                )
+
+            txo, datum = state.swap_utxo(
+                address_source=address_source,
+                in_assets=order_in,
+                out_assets=order_out,
+                tx_builder=tx_builder,
+                owner_address=Address.decode(state.address),
+            )
+
+            in_remaining -= order_in
+            if in_remaining.quantity() <= state.price[0] / state.price[1]:
+                break
+
+        return txo, datum

--- a/tests/test_cardanoswaps.py
+++ b/tests/test_cardanoswaps.py
@@ -1041,3 +1041,152 @@ def test_ref_script_guard_rejects_missing_script(method_name) -> None:
     )
     with pytest.raises(ValueError, match="no output script"):
         getattr(CardanoSwapsOrderState, method_name)(no_script)
+
+
+# --- CardanoSwapsOrderBook (aggregate order book) --------------------------
+#
+# The aggregate over many resting one-way swaps: get_book buckets orders into a
+# buy/sell book, the inherited base level-walk prices across them (fee == 0), and
+# swap_utxo folds a fill order-by-order — threading EACH maker's owner (the resting
+# UTxO's staking credential, carried on ``address``) so the continuation lands at
+# the right beacon-tagged swap address, not the taker's.
+
+from decimal import Decimal
+
+from pycardano import ScriptHash
+
+from charli3_dendrite.dexs.ob.cardanoswaps import CardanoSwapsOrderBook
+
+_PAIR = Assets(root={"lovelace": 0, TOKEN_A_UNIT: 0})
+
+_MAKER = Address(
+    payment_part=VerificationKeyHash(bytes.fromhex("55" * 28)),
+    staking_part=VerificationKeyHash(bytes.fromhex("66" * 28)),
+    network=Network.MAINNET,
+)
+_TAKER = Address(
+    payment_part=VerificationKeyHash(bytes.fromhex("77" * 28)),
+    staking_part=VerificationKeyHash(bytes.fromhex("88" * 28)),
+    network=Network.MAINNET,
+)
+
+
+def _sell_order(num: int, den: int, offer_qty: int) -> CardanoSwapsOrderState:
+    """A token-offer order (offer AAA, ask ADA) -> the SELL side (a -> b is ADA-in)."""
+    return _resting_state(
+        bytes.fromhex(TOKEN_A_POLICY),
+        bytes.fromhex(TOKEN_A_NAME),
+        b"",
+        b"",
+        num,
+        den,
+        offer_qty,
+    )
+
+
+def _ada_offer_order(num: int, den: int, offer_qty: int) -> CardanoSwapsOrderState:
+    """An ADA-offer order (offer ADA, ask AAA) -> the BUY side."""
+    return _resting_state(
+        b"",
+        b"",
+        bytes.fromhex(TOKEN_A_POLICY),
+        bytes.fromhex(TOKEN_A_NAME),
+        num,
+        den,
+        offer_qty,
+    )
+
+
+def _resting_beacon_addr(owner: Address) -> str:
+    """The on-chain resting address: swap-validator payment part + owner staking."""
+    return str(
+        Address(
+            payment_part=ScriptHash(bytes.fromhex(SWAP_VALIDATOR_HASH)),
+            staking_part=owner.staking_part,
+            network=Network.MAINNET,
+        )
+    )
+
+
+def test_orderbook_get_book_orientation_and_levels() -> None:
+    sell = _sell_order(2, 1, 100)  # token offer -> sell book, level price 2, qty 100
+    buy = _ada_offer_order(3, 1, 10_000_000)  # ADA offer -> buy book
+    book = CardanoSwapsOrderBook.get_book(_PAIR, orders=[sell, buy])
+
+    assert book.dex() == "CardanoSwaps"
+    assert len(book.sell_book_full) == 1
+    assert len(book.buy_book_full) == 1
+    assert book.sell_book_full[0].price == 2.0
+    assert book.sell_book_full[0].quantity == 100
+    assert book.buy_book_full[0].price == 3.0
+
+
+def test_orderbook_get_amount_out_walks_multiple_levels() -> None:
+    # Two token-offer (sell) orders at price 2 and 4; the base level-walk fills the
+    # cheaper (ask-per-offer) one first. Prices are raw base-unit rationals.
+    cheap = _sell_order(2, 1, 100)  # 100 AAA at 2 lovelace/AAA -> 200 lovelace cap
+    dear = _sell_order(4, 1, 100)  # 100 AAA at 4 lovelace/AAA -> 400 lovelace cap
+    book = CardanoSwapsOrderBook.get_book(_PAIR, orders=[dear, cheap])  # unordered in
+
+    out, _ = book.get_amount_out(Assets(root={"lovelace": 240}))
+    assert out.unit() == TOKEN_A_UNIT
+    # 200 lovelace fills all 100 AAA of the cheap level; the remaining 40 buys
+    # 40 / 4 = 10 AAA of the dear level. Total 110 AAA.
+    assert out.quantity() == 110
+
+
+def test_orderbook_price_one_sided_returns_zero() -> None:
+    # A book with only sell orders (no buy side) must not crash on the base
+    # price's buy_book[0] deref — the override returns (0, 0).
+    book = CardanoSwapsOrderBook.get_book(_PAIR, orders=[_sell_order(2, 1, 100)])
+    assert not book.buy_book_full
+    assert book.price == (Decimal(0), Decimal(0))
+
+
+def test_orderbook_swap_utxo_threads_maker_owner_not_taker(tx_builder) -> None:
+    # A fill folds through the resting order's OWN owner (from its address), so the
+    # continuation lands at the maker's beacon-tagged swap address — NOT the taker's.
+    order = _ada_offer_order(2, 1, 10_000_000)  # offer 10 ADA, ask AAA @ 2 AAA/ADA
+    order.address = _resting_beacon_addr(_MAKER)
+    book = CardanoSwapsOrderBook.get_book(_PAIR, orders=[order])
+
+    cont_txo, cont_datum = book.swap_utxo(
+        address_source=_TAKER,  # the filler — must NOT become the continuation owner
+        in_assets=Assets(root={TOKEN_A_UNIT: 4_000_000}),
+        out_assets=Assets(root={"lovelace": 2_000_000}),
+        tx_builder=tx_builder,
+    )
+
+    assert cont_txo is not None
+    assert bytes(cont_txo.address.payment_part).hex() == SWAP_VALIDATOR_HASH
+    assert cont_txo.address.staking_part == _MAKER.staking_part
+    assert cont_txo.address.staking_part != _TAKER.staking_part
+
+
+def test_orderbook_swap_utxo_requires_address(tx_builder) -> None:
+    # An order missing its address (owner unknown) must fail loudly, not silently
+    # build a fill owned by the taker.
+    order = _ada_offer_order(2, 1, 10_000_000)
+    assert order.address is None
+    book = CardanoSwapsOrderBook.get_book(_PAIR, orders=[order])
+
+    with pytest.raises(ValueError, match="address"):
+        book.swap_utxo(
+            address_source=_TAKER,
+            in_assets=Assets(root={TOKEN_A_UNIT: 4_000_000}),
+            out_assets=Assets(root={"lovelace": 2_000_000}),
+            tx_builder=tx_builder,
+        )
+
+
+def test_orderstate_retains_address_from_record() -> None:
+    # The backend UTxO record carries the resting address; the order state now
+    # retains it (it was dropped before), so an aggregate fill can recover the owner.
+    datum = _make_datum(
+        b"", b"", bytes.fromhex(TOKEN_A_POLICY), bytes.fromhex(TOKEN_A_NAME), 2, 1
+    )
+    assets = _utxo_assets(datum, {"lovelace": 10_000_000})
+    values = _values_from_datum(datum, assets)
+    values["address"] = _resting_beacon_addr(_MAKER)
+    state = CardanoSwapsOrderState.model_validate(values)
+    assert state.address == _resting_beacon_addr(_MAKER)


### PR DESCRIPTION
## Add `CardanoSwapsOrderBook` aggregate order-book class

Every other order-book DEX in dendrite exposes a **two-class** structure — a single-order `*OrderState` (with `swap_utxo`) *and* an aggregate `*OrderBook(AbstractOrderBookState)` that holds, prices, and fills across many resting orders (`GeniusYieldOrderBook`, `SaturnSwapOrderBook`, `ChadSwapOrderBook`). Cardano-Swaps had only `CardanoSwapsOrderState`, so a caller wanting to price a Cardano-Swaps book had to borrow another DEX's order-book as a generic container.

This adds the missing `CardanoSwapsOrderBook`, modelled on `ChadSwapOrderBook` (the structural match — single order-state class, fee-less, frequently one-sided books):

- **`get_book`** — bucket resting orders into a buy/sell book for a token pair (beacon-policy discovery when `orders` is not supplied).
- **`get_amount_out` / `get_amount_in`** — inherited from the base level-walk. Cardano-Swaps is fee-less (`fee = 0`), so no per-order fee delegation is needed.
- **`price`** — overridden with an empty-book guard: Cardano-Swaps books are frequently one-sided, and the base `price` dereferences the never-populated optional `buy_book[0]` / `sell_book[0]`.
- **`swap_utxo`** — fold a fill across the book, best-price-first, one continuing output per resting order.

### The one Cardano-Swaps-specific wrinkle

Unlike the other order-book DEXes, a Cardano-Swaps order carries **no owner in its datum** — the owner is the resting address's staking credential (the beacon-tagged swap address = validator payment part + owner staking part). The base state model keeps only `assets` / `tx_hash` / `datum_cbor`, so the address was dropped. This PR retains it via a new optional `address` field on `CardanoSwapsOrderState` (populated from the backend UTxO record on ingest), and the fold threads each maker's owner into its per-order `swap_utxo`. Defaulting the owner to the taker (as the other aggregates do) would reconstruct the wrong input and fail validation.

### Tests

Six new hermetic tests in `tests/test_cardanoswaps.py`: `get_book` orientation + levels, aggregate `get_amount_out` across multiple levels, the one-sided-book `price` guard, a real `swap_utxo` fold (via the offline `tx_builder`) asserting the continuation lands at the **maker's** staking credential (not the taker's), the missing-address guard, and address retention through `model_validate`. All pass alongside the existing suite.
