### PR TITLE
fix(lending/danogo): parse collateral liquidation thresholds across CBOR backends

### DIFF
--- a/src/charli3_dendrite/lending/danogo/market.py
+++ b/src/charli3_dendrite/lending/danogo/market.py
@@ -66,7 +66,15 @@ class DanogoMarket(DendriteBaseModel):
 
         collaterals: dict[str, int] = {}
         for key, val in fields[0].items():
-            threshold = val[0] if isinstance(val, (list, tuple)) and val else 0
+            # The threshold is the head of the inner `[threshold_bps, flag]` array.
+            # Plutus arrays decode to a `Sequence` whose concrete type varies by CBOR
+            # backend (a plain `list`, or an indefinite-length `FrozenList`), so match
+            # on `Sequence` rather than the `list`/`tuple` concrete types.
+            is_seq = isinstance(val, Sequence) and not isinstance(
+                val,
+                (str, bytes, bytearray),
+            )
+            threshold = val[0] if is_seq and val else 0
             collaterals[_unit(key)] = int(threshold)
 
         # allow_supply is the Plutus `Bool` True variant; any unexpected encoding


### PR DESCRIPTION
## Summary
`DanogoMarket.from_market_datum` parsed every collateral liquidation threshold as `0`, so `threshold_for()` returned 0 and `DanogoLoanState.health_factor()` returned 0 on every loan.

## Cause
The Market Param datum's per-collateral value is a Plutus array `[threshold_bps, flag]`. Depending on the CBOR backend, a Plutus array decodes either to a plain `list` or to an indefinite-length `FrozenList` — which is **not** a `list`/`tuple` subclass. The guard `isinstance(val, (list, tuple))` was therefore `False` for the `FrozenList` case, defaulting the threshold to 0.

## Fix
Match on `collections.abc.Sequence` (excluding `str`/`bytes`), so both decodings are handled. One-line change in `lending/danogo/market.py` plus an explanatory comment.

## Verification
Against real on-chain Danogo market datums, all collateral thresholds now parse to their true bps (e.g. `8000`/`6000`) instead of 0, and `health_factor()` returns correct values on real loans (previously identically 0). Danogo test suite: 555 passed.

Suggested release: patch bump to `1.5.7`.
