### PR TITLE
fix(dexs/ob): correct Djed and GeniusYield OrderDatum methods

### DIFF
--- a/src/charli3_dendrite/dexs/ob/djed.py
+++ b/src/charli3_dendrite/dexs/ob/djed.py
@@ -316,7 +316,7 @@ class DjedOrderDatum(OrderDatum):
 
     def address_source(self) -> str | None:
         """Source address (required by OrderDatum interface)."""
-        return self.owner_address.to_address().encode("bech32")
+        return self.owner_address.to_address().encode()
 
     def requested_amount(self) -> Assets:
         """Return the requested amount for this order."""
@@ -327,14 +327,14 @@ class DjedOrderDatum(OrderDatum):
             # Invert oracle rate (Djed/ADA -> ADA/Djed) and multiply
             ada_amount = (
                 self.action.djed_amount
-                * self._oracle_rate.denominator
-                // self._oracle_rate.numerator
+                * self.oracle_rate.denominator
+                // self.oracle_rate.numerator
             )
             return Assets(lovelace=ada_amount)
         if isinstance(self.action, ShenMintAction):
             return Assets(**{SHEN_TOKEN: self.action.shen_amount})
         # ShenBurnAction: exact ADA requires pool state which isn't in datum
-        return Assets(lovelace=self.action.shen_amount)
+        return Assets(**{SHEN_TOKEN: self.action.shen_amount})
 
     def order_type(self) -> OrderType | None:
         """Order type classification (required by OrderDatum interface)."""

--- a/src/charli3_dendrite/dexs/ob/geniusyield.py
+++ b/src/charli3_dendrite/dexs/ob/geniusyield.py
@@ -118,20 +118,15 @@ class GeniusYieldOrder(OrderDatum):
         return self.offered_asset.assets + self.asked_asset.assets
 
     def address_source(self) -> str | None:
-        return None
+        return self.owner_address.to_address().encode()
 
     def requested_amount(self) -> Assets:
-        asset = self.offered_asset.assets
-        return asset
+        unit = self.asked_asset.assets.unit()
+        amount = self.offered_amount * self.price.numerator // self.price.denominator
+        return Assets(**{unit: amount})
 
     def order_type(self) -> OrderType | None:
-        order_type = None
-        if self.offered_original_amount == self.offered_amount:
-            order_type = OrderType.deposit
-        else:
-            order_type = OrderType.swap
-
-        return order_type
+        return OrderType.swap
 
 
 @dataclass


### PR DESCRIPTION
Two independent order-book `OrderDatum` method fixes, each verified against real on-chain orders.

## Djed (`dexs/ob/djed.py`)
- `requested_amount()` (burn branch) read `self._oracle_rate` — an OB-state snapshot attribute that only exists after `get_book()`, **not** a datum field — so it raised `AttributeError` on every `from_cbor` datum (and burn is the swap-classified action). Now reads the datum's own `self.oracle_rate`.
- `address_source()` called `.encode("bech32")`; pycardano's `Address.encode()` takes no positional arg, so it raised `TypeError` for every order. Now a bare `.encode()` (matching the other OB datums, e.g. saturnswap/chadswap).
- `ShenBurnAction` branch of `requested_amount()` labeled a SHEN quantity as `lovelace`; now returns the burned amount under `SHEN_TOKEN` (the exact ADA-out needs pool state, noted in the existing comment).

Verified on a real DjedBurn order: `requested_amount()` → `Assets(lovelace=10680828888)` (~10,680.8 ADA); `address_source()` → a valid round-tripping bech32 address. Both raised before.

## GeniusYield (`dexs/ob/geniusyield.py`)
- `order_type()` returned `deposit` for any unfilled order (only partially-filled → `swap`), so fresh resting limit orders — the common case — were misclassified and dropped by swap-gated consumers. A GeniusYield order is always a swap; now returns `OrderType.swap`.
- `requested_amount()` returned the **offered** leg (often quantity 0) instead of the asked leg. Now returns the asked token with amount `offered_amount * price.numerator // price.denominator`.
- `address_source()` returned `None` though the owner is on the datum. Now returns `self.owner_address.to_address().encode()`.

Verified on 4 real GeniusYield orders: `order_type` → `swap`; `requested_amount` → the asked leg with real amounts (e.g. `{GENS: 501504514}`, `{USDM: 389450}`, `{lovelace: 51940000}`); `address_source` → the owner (its payment part matches the datum `owner_key` on all 4).

Both fixes are pure and read only the datum's own fields (no backend/pool-state access), matching the `OrderDatum` contract.
