### PR TITLE
fix(lending/danogo): correct and deterministic multi-market health factor

### DIFF
--- a/src/charli3_dendrite/lending/danogo/loader.py
+++ b/src/charli3_dendrite/lending/danogo/loader.py
@@ -28,7 +28,10 @@ from charli3_dendrite.lending.danogo.state import DanogoLoanState
 from charli3_dendrite.lending.danogo.state import DanogoPoolState
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from charli3_dendrite.backend.backend_base import AbstractBackend
+    from charli3_dendrite.dataclasses.models import Assets
     from charli3_dendrite.dataclasses.models import PoolStateInfo
     from charli3_dendrite.lending.oracles.models import PriceMap
 
@@ -99,6 +102,29 @@ def _pool_nft_name(info: PoolStateInfo, policy: str) -> str | None:
         if unit != "lovelace" and unit.startswith(policy) and qty == 1:
             name = unit[len(policy) :]
             if name:
+                return name
+    return None
+
+
+def _loan_market_name(
+    assets: Assets,
+    loan_policy: str,
+    valid_names: Collection[str],
+) -> str | None:
+    """Pool-NFT name (hex) of the market a loan belongs to, from its loan-identity NFT.
+
+    Each loan UTxO carries a loan token minted under the loan script hash whose asset
+    name IS the pool-NFT name of the loan's market (`create_loan` mints it that way).
+    Mirroring `_pool_nft_name`, this reads that name directly off the loan rather than
+    guessing the market from the borrowed supply token (several markets can share a
+    supply token) or the collateral (several markets can accept the same collateral).
+    Returns the name only when it is a known market/pool name (in `valid_names`), else
+    None (the loan is skipped, matching the existing skip-on-parse-failure degrade).
+    """
+    for unit, qty in assets.root.items():
+        if unit != "lovelace" and unit.startswith(loan_policy) and qty == 1:
+            name = unit[len(loan_policy) :]
+            if name in valid_names:
                 return name
     return None
 
@@ -193,9 +219,22 @@ def snapshot(
     if prices is None:
         try:
             from charli3_dendrite.lending.danogo.oracles import forward
+            from charli3_dendrite.lending.danogo.oracles.locator import (
+                augment_registry_with_bond_dtokens,
+            )
             from charli3_dendrite.lending.danogo.oracles.locator import load_registry
 
             registry = load_registry()
+            # Bond dTokens (a pool's own redeemable dToken) are accepted as collateral
+            # but are not mined for every (dToken, quote); synthesize their pricing
+            # recipes from the live pool/market state before resolving, so a dToken
+            # collateral prices instead of collapsing the loan's health factor.
+            augment_registry_with_bond_dtokens(
+                registry,
+                pool_address=addresses["pool"],
+                config_pool_cred=_payment_cred_hex(addresses["config_pool"]),
+                markets=markets,
+            )
             pairs = {
                 (collateral, market.supply_token)
                 for market in markets.values()
@@ -205,28 +244,26 @@ def snapshot(
         except Exception:  # noqa: BLE001 - pricing outage must not crash the snapshot
             prices = PriceMap()
 
-    # Pair pool <-> market (same pool-NFT name) and index pools by supply token so
-    # loans (which only know their borrowed token) can find their market/pool.
+    # Pair pool <-> market (same pool-NFT name) and index BY THAT NAME. Each loan is
+    # stitched to the market its own loan-identity NFT names -- not one guessed from its
+    # borrowed supply token or collateral, both of which several markets can share.
     pools: list[DanogoPoolState] = []
-    by_supply: dict[str, tuple[DanogoPoolState, DanogoMarket]] = {}
+    by_name: dict[str, tuple[DanogoPoolState, DanogoMarket]] = {}
     for name, pool in pools_by_name.items():
         market = markets.get(name)
         if market is None:
             continue
         pool.attach_market(market)
         pools.append(pool)
-        by_supply[market.supply_token] = (pool, market)
+        by_name[name] = (pool, market)
 
+    loan_policy = _payment_cred_hex(addresses["loan"])
     stitched: list[DanogoLoanState] = []
     for loan in loans:
-        try:
-            supply = loan.borrowed_unit
-        except (ValueError, IndexError, TypeError, AttributeError):
+        loan_market = _loan_market_name(loan.assets, loan_policy, by_name)
+        if loan_market is None:
             continue
-        ctx = by_supply.get(supply)
-        if ctx is None:
-            continue
-        pool, market = ctx
+        pool, market = by_name[loan_market]
         loan.attach_context(pool=pool, market=market, now_ms=now_ms)
         stitched.append(loan)
 

--- a/src/charli3_dendrite/lending/danogo/oracles/forward.py
+++ b/src/charli3_dendrite/lending/danogo/oracles/forward.py
@@ -296,10 +296,6 @@ def resolve_prices(
     Emits ``OraclePrice(token=..., quote=quote, ...)``. A pair with no recipe, a
     missing leaf, or a non-reproducing walk is simply omitted (collateral stays unpriced
     -> not-liquidatable). Never raises into the caller.
-
-    NOTE: ``PriceMap`` keys by token only, so a collateral used across markets with
-    different supply tokens can hold only one quote. That's a pre-existing PriceMap
-    constraint, not handled here.
     """
     pm = PriceMap()
     for collateral, quote in pairs:

--- a/src/charli3_dendrite/lending/danogo/oracles/locator.py
+++ b/src/charli3_dendrite/lending/danogo/oracles/locator.py
@@ -17,6 +17,28 @@ from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass
 from importlib.resources import files
+from typing import TYPE_CHECKING
+
+from pycardano import Address
+
+if TYPE_CHECKING:
+    from charli3_dendrite.lending.danogo.market import DanogoMarket
+
+# The Danogo pool redemption leaf kind (an ``OracleUtxoType`` member name). Named as a
+# literal here to keep the recipe assembler free of the oracle-redeemer import; it is
+# the same string the mined recipes and `forward.leaf_rate` dispatch on.
+_BOND_DTOKEN_OTYPE = "TDANOGO_POOL"
+# ADA is the universal intermediate quote for cross-quote composition (mirrors
+# `forward.INTERMEDIATE_QUOTE`; redeclared to avoid importing the forward module, which
+# imports this one).
+_INTERMEDIATE_QUOTE = "lovelace"
+# On-chain unit = 28-byte policy id (56 hex chars) followed by the asset name (hex).
+_POLICY_ID_HEX_LEN = 56
+
+
+def _payment_cred_hex(address: str) -> str:
+    """Payment-credential (script hash) hex of an enterprise/base address."""
+    return Address.decode(address).payment_part.payload.hex()
 
 
 @dataclass(frozen=True)
@@ -138,3 +160,141 @@ def registry_from_dict(data: Mapping[str, Mapping]) -> dict[str, Recipe]:
         )
         out[unit] = Recipe(steps=steps)
     return out
+
+
+def _reverse_steps(steps: tuple[RecipeStep, ...]) -> tuple[RecipeStep, ...]:
+    """Reverse a recipe's steps so the composed rate is inverted.
+
+    Each step contributes ``rate**(±1) * 10**scale_exp``; the reciprocal of the whole
+    product flips every step's orientation and negates its scale, in reverse order. The
+    leaf handles are unchanged, so the reversed steps resolve to the same live UTxOs.
+    """
+    return tuple(
+        RecipeStep(
+            handle=s.handle,
+            is_reverse=not s.is_reverse,
+            scale_exp=-s.scale_exp,
+        )
+        for s in reversed(steps)
+    )
+
+
+def synthesize_bond_dtoken_recipe(
+    collateral: str,
+    quote: str,
+    *,
+    pool_address: str,
+    config_pool_cred: str,
+    markets: Mapping[str, DanogoMarket],
+    registry: Mapping[str, Recipe],
+) -> Recipe | None:
+    """Assemble a live pricing `Recipe` for a Danogo bond-dToken collateral, or None.
+
+    A bond dToken's on-chain unit is ``<pool script hash> + N`` where ``N`` is a live
+    pool/market NFT name; the dToken's own pool redeems it into the market's supply
+    token at ``total_supply / circulating_dtoken`` (the ``TDANOGO_POOL`` leaf, priced
+    bit-exact by `reproduce`/`leaves`). This ASSEMBLES the recipe that reprices such a
+    dToken into `quote`; it computes no rate -- `forward.replay_recipe` /
+    `forward.compose_cross_quote` do, over the same leaf handles the mined recipes use.
+
+    `collateral` is recognised as a bond dToken only when its policy id is the
+    deployment's pool validator hash (derived from `pool_address`, resolved from
+    on-chain config -- never hardcoded) AND its asset name is a known pool/market name
+    (``markets`` keyed by ``N``). Requiring the policy, not the name alone, rejects an
+    unrelated token that happens to reuse a pool/market name as its asset name, while
+    staying deployment-agnostic (no hardcoded policy, no pool from another deployment).
+    Four cases:
+
+    * ``underlying == quote`` -- the single redemption step prices the dToken directly.
+    * a mined ``underlying|quote`` recipe exists -- append the redemption to it.
+    * ``quote == ADA`` (``underlying != ADA``) -- ``dToken -> underlying -> ADA``: the
+      redemption times the reversed ``lovelace|underlying`` recipe, priced in ADA.
+    * cross-quote (the registry has ``lovelace|underlying`` and ``lovelace|quote``) --
+      ``dToken -> underlying -> ADA -> quote`` shaped for `compose_cross_quote`'s
+      pool-leading branch (the redemption leads, the reversed ``lovelace|underlying``
+      values it in ADA, and a trailing bridge step is dropped in favour of the resolved
+      ``lovelace|quote`` intermediate).
+    * otherwise None -- no fabricated price; the collateral stays unpriced
+      (not-liquidatable), the existing safe degrade.
+    """
+    # A bond dToken is minted under the Danogo pool validator hash: its unit is
+    # ``<pool script hash> + <pool/market name>``. Require BOTH the policy id (the pool
+    # validator hash, from `pool_address`) and a known pool/market name, so an unrelated
+    # token that merely reuses a pool/market name is not mistaken for a bond dToken.
+    name = collateral[_POLICY_ID_HEX_LEN:]
+    market = markets.get(name)
+    if market is None or collateral[:_POLICY_ID_HEX_LEN] != _payment_cred_hex(
+        pool_address,
+    ):
+        return None
+    redemption_step = RecipeStep(
+        handle=LeafHandle(
+            otype=_BOND_DTOKEN_OTYPE,
+            address=pool_address,
+            nft_policy=config_pool_cred,
+            nft_name=name,
+            datum_key="",
+        ),
+        is_reverse=False,
+        scale_exp=0,
+    )
+    underlying = market.supply_token
+    if underlying == quote:
+        return Recipe(steps=(redemption_step,))
+    conv = registry.get(f"{underlying}|{quote}")
+    if conv is not None:
+        return Recipe(steps=(*conv.steps, redemption_step))
+
+    # Compose through ADA: value the dToken in ADA via its redemption then the reversed
+    # ADA->underlying recipe (ADA is the universal intermediate). No bridge -> unpriced.
+    under_from_ada = registry.get(f"{_INTERMEDIATE_QUOTE}|{underlying}")
+    if under_from_ada is None:
+        return None
+    underlying_to_ada = _reverse_steps(under_from_ada.steps)
+    if quote == _INTERMEDIATE_QUOTE:
+        # Target IS ADA: dToken -> underlying -> ADA, priced single-hop in ADA.
+        steps = (redemption_step, *underlying_to_ada)
+    elif (ada_to_quote := registry.get(f"{_INTERMEDIATE_QUOTE}|{quote}")) is not None:
+        # Cross-quote pool-leading shape: (redemption, underlying->ADA, dropped bridge).
+        # compose_cross_quote values the collateral in ADA over all-but-the-last steps,
+        # and takes ADA->quote from the separately-resolved lovelace|quote intermediate,
+        # dropping the trailing step -- it only has to resolve live; its rate is unused.
+        steps = (redemption_step, *underlying_to_ada, ada_to_quote.steps[0])
+    else:
+        return None
+    return Recipe(steps=steps)
+
+
+def augment_registry_with_bond_dtokens(
+    registry: dict[str, Recipe],
+    *,
+    pool_address: str,
+    config_pool_cred: str,
+    markets: Mapping[str, DanogoMarket],
+) -> dict[str, Recipe]:
+    """Add synthesized bond-dToken recipes to `registry` in place; return it.
+
+    For every market's accepted collateral that is a bond dToken with no mined recipe
+    for that market's quote, synthesize one (`synthesize_bond_dtoken_recipe`) and
+    register it under ``f"{collateral}|{quote}"``. Additive: mined recipes are never
+    overwritten, and a collateral with no composable path is left unpriced. Both live
+    seams that consult the registry -- `loader.snapshot` and the tx-builder leaf
+    resolution -- call this so they price bond dTokens identically.
+    """
+    for market in markets.values():
+        quote = market.supply_token
+        for collateral in market.collaterals:
+            key = f"{collateral}|{quote}"
+            if key in registry:
+                continue
+            recipe = synthesize_bond_dtoken_recipe(
+                collateral,
+                quote,
+                pool_address=pool_address,
+                config_pool_cred=config_pool_cred,
+                markets=markets,
+                registry=registry,
+            )
+            if recipe is not None:
+                registry[key] = recipe
+    return registry

--- a/src/charli3_dendrite/lending/danogo/state.py
+++ b/src/charli3_dendrite/lending/danogo/state.py
@@ -177,7 +177,7 @@ class DanogoLoanState(AbstractLoanState):
         terms: list[tuple[int, int, int, int]] = []
         has_missing = False
         for unit, amount in self._collateral_units().items():
-            price = prices.get(unit)
+            price = prices.get(unit, quote=market.supply_token)
             if price is None or price.num <= 0 or price.denom <= 0:
                 has_missing = True
                 continue

--- a/src/charli3_dendrite/lending/fluidtokens/state.py
+++ b/src/charli3_dendrite/lending/fluidtokens/state.py
@@ -259,7 +259,7 @@ class FluidLoanState(AbstractLoanState):
         """
         unit = self._collateral_unit()
         amount = self.assets[unit]
-        price = prices.get(unit)
+        price = prices.get(unit, quote=self.borrowed_unit)
         if price is None or price.num <= 0 or price.denom <= 0:
             return 0
         return amount * price.num // price.denom
@@ -299,7 +299,7 @@ class FluidLoanState(AbstractLoanState):
         we do NOT flag it (avoids false positives during oracle outages).
         """
         unit = self._collateral_unit()
-        price = prices.get(unit)
+        price = prices.get(unit, quote=self.borrowed_unit)
         if price is None or price.num <= 0 or price.denom <= 0:
             return False
         return self.health_factor(prices) <= 1

--- a/src/charli3_dendrite/lending/oracles/models.py
+++ b/src/charli3_dendrite/lending/oracles/models.py
@@ -13,6 +13,8 @@ from typing import Protocol
 from typing import runtime_checkable
 
 from pydantic import Field
+from pydantic import field_serializer
+from pydantic import field_validator
 
 from charli3_dendrite.dataclasses.models import DendriteBaseModel
 from charli3_dendrite.dataclasses.models import PoolSelector
@@ -104,34 +106,68 @@ class OracleRef(DendriteBaseModel):
 
 
 class PriceMap(DendriteBaseModel):
-    """token -> freshest OraclePrice."""
+    """(token, quote) -> freshest OraclePrice.
 
-    prices: dict[str, OraclePrice] = Field(default_factory=dict)
+    A collateral can be priced under more than one market quote (e.g. ADA priced
+    into several supply tokens), so the identity is the price's own ``(token,
+    quote)`` pair, not the token alone. Keying by token alone let same-token,
+    different-quote prices collide, making reads non-deterministic; keying by the
+    pair keeps each quote's price distinct.
+    """
+
+    prices: dict[tuple[str, str], OraclePrice] = Field(default_factory=dict)
+
+    # The `(token, quote)` tuple keys have no symmetric JSON form: pydantic dumps a
+    # tuple key as ``"token,quote"`` but cannot parse it back. Encode each key as
+    # ``"token|quote"`` on dump and split it back on validate so both `model_dump`/
+    # `model_validate` and `model_dump_json`/`model_validate_json` round-trip. Units are
+    # hex or "lovelace" and never contain ``|``.
+    @field_serializer("prices")
+    def _serialize_prices(
+        self,
+        prices: dict[tuple[str, str], OraclePrice],
+    ) -> dict[str, OraclePrice]:
+        return {f"{token}|{quote}": price for (token, quote), price in prices.items()}
+
+    @field_validator("prices", mode="before")
+    @classmethod
+    def _parse_price_keys(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        parsed: dict[object, object] = {}
+        for key, price in value.items():
+            if isinstance(key, str):
+                token, quote = key.split("|", 1)
+                parsed[(token, quote)] = price
+            else:
+                parsed[key] = price
+        return parsed
 
     def add(self, price: OraclePrice) -> None:
-        """Insert `price`, keeping the one with the latest `valid_to`.
+        """Insert `price` under its ``(token, quote)``, keeping the latest `valid_to`.
 
         A `valid_to` of `None` means "no expiry" and is treated as the freshest
         possible value (`+inf`), so an open-ended price is never overwritten by
-        a dated one and always overwrites a dated one for the same token.
+        a dated one and always overwrites a dated one for the same ``(token, quote)``.
         """
 
         def _key(p: OraclePrice) -> float:
             return float("inf") if p.valid_to is None else p.valid_to
 
-        existing = self.prices.get(price.token)
+        pair = (price.token, price.quote)
+        existing = self.prices.get(pair)
         if existing is None or _key(price) >= _key(existing):
-            self.prices[price.token] = price
+            self.prices[pair] = price
 
-    def get(self, token: str) -> OraclePrice | None:
-        """Return the stored price for `token`, or None if absent."""
-        return self.prices.get(token)
+    def get(self, token: str, quote: str = "lovelace") -> OraclePrice | None:
+        """Return the stored price for ``(token, quote)``, or None if absent."""
+        return self.prices.get((token, quote))
 
-    def require(self, token: str) -> OraclePrice:
-        """Return the stored price for `token`, or raise KeyError."""
-        price = self.prices.get(token)
+    def require(self, token: str, quote: str = "lovelace") -> OraclePrice:
+        """Return the stored price for ``(token, quote)``, or raise KeyError."""
+        price = self.prices.get((token, quote))
         if price is None:
-            raise KeyError(f"no price for {token}")
+            raise KeyError(f"no price for {token} in {quote}")
         return price
 
 

--- a/tests/lending/danogo/test_forward_compose.py
+++ b/tests/lending/danogo/test_forward_compose.py
@@ -89,9 +89,9 @@ def test_analytics_prices_cross_quote_market_byte_exact(
     # Every entry the tx builder / on-chain redeemer declares under this quote -- the
     # intermediate ada price and the composed collateral price -- is reproduced exactly.
     assert tx_prices[quote] == captured.prices[quote]
-    assert set(pm.prices) == set(captured.prices[quote])
+    assert {token for token, _q in pm.prices} == set(captured.prices[quote])
     for token, (num, denom) in captured.prices[quote].items():
-        price = pm.get(token)
+        price = pm.get(token, quote=quote)
         assert price is not None
         assert price.quote == quote
         assert (price.num, price.denom) == (num, denom)

--- a/tests/lending/danogo/test_forward_prices_wiring.py
+++ b/tests/lending/danogo/test_forward_prices_wiring.py
@@ -58,7 +58,7 @@ def test_resolve_prices_reproduces_a_captured_price():
     pm = resolve_prices(
         backend, registry=registry, pairs=[(case["token"], case["quote"])]
     )
-    price = pm.get(case["token"])
+    price = pm.get(case["token"], quote=case["quote"])
     assert price is not None
     from fractions import Fraction
 

--- a/tests/lending/danogo/test_loader.py
+++ b/tests/lending/danogo/test_loader.py
@@ -76,3 +76,32 @@ def test_build_book_empty_inputs():
     book = build_book(pools=[], loans=[], prices=PriceMap(), now_ms=0)
     assert isinstance(book, LendingBook)
     assert book.active_loans() == []
+
+
+def test_loan_market_name_reads_identity_nft():
+    # Bug-A core: a loan is stitched to the market its own loan-identity NFT names,
+    # not one guessed from its borrowed token or collateral. Two markets can share a
+    # supply token, so name-keying (not supply-keying) is what disambiguates.
+    from charli3_dendrite.dataclasses.models import Assets
+    from charli3_dendrite.lending.danogo.loader import _loan_market_name
+
+    loan_policy = "cd" * 28
+    name_a, name_b = "aa" * 28, "bb" * 28
+    valid = {name_a, name_b}
+
+    carries_b = Assets(
+        root={
+            "lovelace": 2_000_000,
+            loan_policy + name_b: 1,  # loan-identity NFT for market B
+            "ff" * 28 + "0011": 5_000,  # unrelated collateral
+        }
+    )
+    assert _loan_market_name(carries_b, loan_policy, valid) == name_b
+
+    # An identity NFT whose name is not a known market -> None (loan skipped, safe).
+    unknown = Assets(root={"lovelace": 1, loan_policy + "cc" * 28: 1})
+    assert _loan_market_name(unknown, loan_policy, valid) is None
+
+    # No identity NFT at all -> None.
+    bare = Assets(root={"lovelace": 1})
+    assert _loan_market_name(bare, loan_policy, valid) is None

--- a/tests/lending/danogo/test_loader_snapshot.py
+++ b/tests/lending/danogo/test_loader_snapshot.py
@@ -43,6 +43,19 @@ def _info(address, asset_rows, datum, value=2_000_000):
     )
 
 
+def _loan_rows_for_market(loan_fixture, loan_skh, market_name):
+    """Point a captured loan's identity NFT at `market_name` (the served market).
+
+    A loan is stitched to the market its loan-identity NFT (policy == loan script hash)
+    names. Captured loans carry the NFT for their OWN market; these fixtures serve a
+    single market, so retarget the identity NFT to it to exercise the name-keyed stitch.
+    """
+    return [
+        (policy, market_name if policy == loan_skh else name, qty)
+        for policy, name, qty in loan_fixture["assets"]
+    ]
+
+
 class _FakeBackend:
     """Dispatches get_pool_utxos by config-NFT (resolve) or payment credential."""
 
@@ -67,9 +80,14 @@ def _backend():
     config_pool_addr = constants._addr(pd.config_pool_skh.hex())
     loan_addr = constants._addr(pd.loan_skh.hex())
 
+    config_pool_skh = pd.config_pool_skh.hex()
+    market_name = next(
+        n for p, n, _ in FIXTURES["market_param"]["assets"] if p == config_pool_skh
+    )
+
     config_row = _info(config_pool_addr, [], FIXTURES["protocol_config"]["datum"])
     by_cred = {
-        pd.config_pool_skh.hex(): [
+        config_pool_skh: [
             _info(
                 config_pool_addr,
                 FIXTURES["market_param"]["assets"],
@@ -86,7 +104,9 @@ def _backend():
         pd.loan_skh.hex(): [
             _info(
                 loan_addr,
-                FIXTURES["ada_loan"]["assets"],
+                _loan_rows_for_market(
+                    FIXTURES["ada_loan"], pd.loan_skh.hex(), market_name
+                ),
                 FIXTURES["ada_loan"]["datum"],
             )
         ],

--- a/tests/lending/test_oracle_models.py
+++ b/tests/lending/test_oracle_models.py
@@ -46,6 +46,39 @@ def test_pricemap_require_missing_raises():
         pm.require("missing")
 
 
+def test_pricemap_keyed_by_token_and_quote():
+    # The same collateral priced under two different quotes must NOT collide: each
+    # (token, quote) pair keeps its own price, and reads disambiguate by quote.
+    pm = PriceMap()
+    pm.add(
+        _price(token="A", num=3, denom=2, src=OracleSource.CHARLI3)
+    )  # quote=lovelace
+    pm.add(
+        OraclePrice(
+            token="A", quote="USDM", num=7, denom=5, source=OracleSource.CHARLI3
+        )
+    )
+    assert pm.get("A", quote="lovelace").as_decimal() == Decimal("1.5")
+    assert pm.get("A", quote="USDM").as_decimal() == Decimal("1.4")
+    assert pm.get("A") is pm.get("A", quote="lovelace")  # default quote is lovelace
+    assert pm.get("A", quote="OTHER") is None
+
+
+def test_pricemap_json_roundtrip_symmetric():
+    # The (token, quote) tuple keys must survive BOTH the python and the JSON
+    # round-trips: pydantic's default tuple-key JSON form is not re-parseable, so the
+    # model encodes each key as "token|quote" on dump and splits it back on validate.
+    pm = PriceMap()
+    pm.add(_price(token="A", num=3, denom=2))  # quote=lovelace
+    pm.add(
+        OraclePrice(
+            token="A", quote="USDM", num=7, denom=5, source=OracleSource.CHARLI3
+        )
+    )
+    assert PriceMap.model_validate(pm.model_dump()) == pm
+    assert PriceMap.model_validate_json(pm.model_dump_json()) == pm
+
+
 def test_oracleref_selector_from_feed_nft():
     ref = OracleRef(
         source=OracleSource.CHARLI3,


### PR DESCRIPTION
Fixes three coupled bugs that made `DanogoLoanState.health_factor` unusable — it collapsed to ~0 on real loans and returned a **non-deterministic** liquidatable set run-to-run.

### 1. `loader.snapshot` mis-stitched loans to markets
`by_supply` kept one market per supply token (last-writer-wins), so a loan whose supply token has more than one market attached to a market that doesn't recognise its collateral → collateral value 0 → HF 0 (false-liquidatable). Now each loan is stitched to its market by the **loan-identity NFT it carries** (the pool-NFT name), mirroring the existing `_pool_nft_name`, instead of guessing from the supply token.

### 2. `PriceMap` keyed by collateral token only → non-deterministic HF
A collateral priced against different quotes in different markets collided; one quote won by dict-iteration order. Now keyed by `(token, quote)`; `get`/`require` take a `quote` (default `lovelace`); callers pass the loan's supply token. Keys serialize symmetrically as `"token|quote"`.

### 3. Bond dTokens held as collateral were unpriced
dTokens minted by the pool script had no price source → value ~0. A recipe **synthesizer** prices them, on a registry miss, from the pool redemption rate (reusing the existing pool-dToken-rate leaf) through the **same recipe/registry seam** the forward resolver already uses — recognised only when the collateral's policy id is the deployment's pool script hash.

### Verification (live mainnet)
- **Deterministic:** liquidatable count `{44,22,15,15,0}` (unstable) → `{0,…}` identical across `PYTHONHASHSEED` seeds, all 80 per-loan HFs byte-identical (control: reverting only the key restores the seed swing).
- **Correct:** bond-collateral anchor HF `~1.6e-8` → `2.44` (redemption rate hand-checked; 17/17 synthesized recipes reproduce mined prices ≤0.6%, inside the on-chain tolerance). Stitch anchor now attaches to the right market (HF `7.42`). Final book: 75/80 fully priced, all HF>1 — genuinely healthy, matching an independent on-chain analysis.
- Danogo suite: 559 passed. All fixes read only datum/pool state; no new resolver, no new pattern.

### Notes
- Scoped to the read/health-factor path. The tx-builder is intentionally **not** wired to bond-dToken pricing here (a cross-quote recipe needs a small extra step for the build path); that's a separate change.
- With bond dTokens now priced, a full snapshot resolves more oracle leaves, so it's slower over a remote dbsync (cheap on a local/deployment node).
