### PR TITLE
fix: forward-order receiver corrections for swap forwarding

### DIFF
--- a/src/charli3_dendrite/dexs/amm/amm_base.py
+++ b/src/charli3_dendrite/dexs/amm/amm_base.py
@@ -79,6 +79,7 @@ class AbstractPoolState(AbstractPairState):
         extra_assets: Assets | None = None,
         address_target: Address | None = None,
         datum_target: PlutusData | None = None,
+        minimum_receive: Assets | None = None,
     ) -> PlutusData:
         """Create a swap datum for the pool.
 
@@ -92,6 +93,8 @@ class AbstractPoolState(AbstractPairState):
             Defaults to None.
             datum_target (PlutusData | None, optional): The target datum for the swap.
             Defaults to None.
+            minimum_receive (Assets | None, optional): Overrides the baked on-chain
+            minimum; fee and deposit still size from out_assets. Defaults to None.
 
         Returns:
             PlutusData: The created swap datum.
@@ -104,10 +107,14 @@ class AbstractPoolState(AbstractPairState):
                 f"{self.__class__.__name__} does not support swap forwarding.",
             )
 
+        # ``minimum_receive`` (when set) becomes the datum's baked floor; the batcher
+        # fee and deposit are still derived from the EXACT ``out_assets`` so relaxing
+        # the floor never under-fees the order — only the step's ``minimum_receive``
+        # loosens. Same output unit, so swap direction and lp_asset are unaffected.
         return self.order_datum_class().create_datum(
             address_source=address_source,
             in_assets=in_assets,
-            out_assets=out_assets,
+            out_assets=out_assets if minimum_receive is None else minimum_receive,
             batcher_fee=self.batcher_fee(
                 in_assets=in_assets,
                 out_assets=out_assets,
@@ -127,6 +134,7 @@ class AbstractPoolState(AbstractPairState):
         extra_assets: Assets | None = None,
         address_target: Address | None = None,
         datum_target: PlutusData | None = None,
+        minimum_receive: Assets | None = None,
     ) -> tuple[TransactionOutput | None, PlutusData]:
         """Create a swap UTXO for the pool.
 
@@ -141,6 +149,8 @@ class AbstractPoolState(AbstractPairState):
             Defaults to None.
             datum_target (PlutusData | None, optional): The target datum for the swap.
             Defaults to None.
+            minimum_receive (Assets | None, optional): Overrides the baked on-chain
+            minimum; fee and deposit still size from out_assets. Defaults to None.
 
         Returns:
             tuple[TransactionOutput, PlutusData]: A tuple containing the created
@@ -163,6 +173,7 @@ class AbstractPoolState(AbstractPairState):
             extra_assets=extra_assets,
             address_target=address_target,
             datum_target=datum_target,
+            minimum_receive=minimum_receive,
         )
 
         in_assets.root["lovelace"] = (

--- a/src/charli3_dendrite/dexs/amm/minswap.py
+++ b/src/charli3_dendrite/dexs/amm/minswap.py
@@ -32,6 +32,7 @@ from charli3_dendrite.dexs.amm.amm_types import AbstractConstantProductPoolState
 from charli3_dendrite.dexs.amm.sundae import SundaeV3PlutusNone
 from charli3_dendrite.dexs.amm.sundae import SundaeV3ReceiverDatumHash
 from charli3_dendrite.dexs.amm.sundae import SundaeV3ReceiverInlineDatum
+from charli3_dendrite.dexs.amm.sundae import SundaeV3ReceiverInlineDatumHash
 from charli3_dendrite.utility import Assets
 
 
@@ -506,12 +507,14 @@ class MinswapV2OrderDatum(OrderDatum):
     refund_datum_hash: Union[
         SundaeV3PlutusNone,
         SundaeV3ReceiverDatumHash,
+        SundaeV3ReceiverInlineDatumHash,
         SundaeV3ReceiverInlineDatum,
     ]
     receiver_address: PlutusFullAddress
     receiver_datum_hash: Union[
         SundaeV3PlutusNone,
         SundaeV3ReceiverDatumHash,
+        SundaeV3ReceiverInlineDatumHash,
         SundaeV3ReceiverInlineDatum,
     ]
     lp_asset: AssetClass
@@ -546,16 +549,31 @@ class MinswapV2OrderDatum(OrderDatum):
         full_address_source = PlutusFullAddress.from_address(address_source)
         step = SwapExactInV2.from_assets(in_asset=in_assets, out_asset=out_assets)
 
-        # `datum_target` is the INNER next-hop order datum (consistent with
-        # Sundae / WingRiders); wrap it as the receiver's inline datum. No
-        # target (or no datum) -> no receiver datum.
+        # Minswap V2's ExtraDatum carries only the 32-byte HASH of the datum the
+        # batcher attaches to the forwarded output (Constr 1 for a datum-hash output,
+        # Constr 2 for an inline-datum output) — never the datum itself; the validator
+        # un_b_data's the field, so an embedded datum is unspendable. `datum_target` is
+        # either a ready receiver form built by the caller (whose form encodes what the
+        # next-hop protocol expects) or a raw next-hop order datum, which is forwarded
+        # by inline-datum-hash. No target (or no datum) -> no receiver datum.
         if address_target is None:
             address_target = address_source
             receiver_datum = SundaeV3PlutusNone()
         elif datum_target is None:
             receiver_datum = SundaeV3PlutusNone()
+        elif isinstance(
+            datum_target,
+            (
+                SundaeV3PlutusNone,
+                SundaeV3ReceiverDatumHash,
+                SundaeV3ReceiverInlineDatumHash,
+            ),
+        ):
+            receiver_datum = datum_target
         else:
-            receiver_datum = SundaeV3ReceiverInlineDatum(datum=datum_target)
+            receiver_datum = SundaeV3ReceiverInlineDatumHash(
+                datum_hash=datum_target.hash().payload,
+            )
 
         full_address_target = PlutusFullAddress.from_address(address_target)
 

--- a/src/charli3_dendrite/dexs/amm/spectrum.py
+++ b/src/charli3_dendrite/dexs/amm/spectrum.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import Any
 from typing import ClassVar
-from typing import List  # noqa: UP035
+from typing import List
 from typing import Union
 
 from pycardano import Address
@@ -366,6 +366,7 @@ class SpectrumCPPState(AbstractConstantProductPoolState):
         extra_assets: Assets | None = None,
         address_target: Address | None = None,
         datum_target: PlutusData | None = None,
+        minimum_receive: Assets | None = None,
     ) -> PlutusData:
         """Create a PlutusData object representing a swap datum.
 
@@ -400,7 +401,7 @@ class SpectrumCPPState(AbstractConstantProductPoolState):
         return SpectrumOrderDatum.create_datum(
             address_source=address_source,
             in_assets=in_assets,
-            out_assets=out_assets,
+            out_assets=out_assets if minimum_receive is None else minimum_receive,
             batcher_fee=self.batcher_fee(in_assets=in_assets, out_assets=out_assets)[
                 "lovelace"
             ],

--- a/src/charli3_dendrite/dexs/amm/sundae.py
+++ b/src/charli3_dendrite/dexs/amm/sundae.py
@@ -123,6 +123,19 @@ class SundaeV3ReceiverInlineDatum(PlutusData):
 
 
 @dataclass
+class SundaeV3ReceiverInlineDatumHash(PlutusData):
+    """Inline-datum receiver identified by the 32-byte hash of the datum the batcher
+    attaches inline to the forwarded output (``Constr 2 [B <hash>]``). Unlike
+    ``SundaeV3ReceiverInlineDatum``, which embeds the datum itself, receivers such as
+    Minswap V2 carry only the hash and verify the attached inline datum against it.
+    """
+
+    CONSTR_ID = 2
+
+    datum_hash: bytes
+
+
+@dataclass
 class SundaeAddressWithDatum(PlutusData):
     """SundaeSwap address with datum."""
 
@@ -602,6 +615,7 @@ class SundaeSwapCPPState(AbstractConstantProductPoolState):
         extra_assets: Assets | None = None,
         address_target: Address | None = None,
         datum_target: PlutusData | None = None,
+        minimum_receive: Assets | None = None,
     ) -> PlutusData:
         """Create a swap datum."""
         if self.swap_forward and address_target is not None:
@@ -613,7 +627,7 @@ class SundaeSwapCPPState(AbstractConstantProductPoolState):
             ident=ident,
             address_source=address_source,
             in_assets=in_assets,
-            out_assets=out_assets,
+            out_assets=out_assets if minimum_receive is None else minimum_receive,
             fee=self.batcher_fee(in_assets=in_assets, out_assets=out_assets).quantity(),
         )
 
@@ -754,6 +768,7 @@ class SundaeSwapV3CPPState(AbstractConstantProductPoolState):
         extra_assets: Assets | None = None,
         address_target: Address | None = None,
         datum_target: PlutusData | None = None,
+        minimum_receive: Assets | None = None,
     ) -> PlutusData:
         ident = bytes.fromhex(self.pool_nft.unit()[64:])
 
@@ -761,7 +776,7 @@ class SundaeSwapV3CPPState(AbstractConstantProductPoolState):
             ident=ident,
             address_source=address_source,
             in_assets=in_assets,
-            out_assets=out_assets,
+            out_assets=out_assets if minimum_receive is None else minimum_receive,
             fee=self.batcher_fee(in_assets=in_assets, out_assets=out_assets).quantity(),
             address_target=address_target,
             datum_target=datum_target,
@@ -932,6 +947,7 @@ class SundaeSwapV3StableSwap(AbstractStableSwapPoolState):
         extra_assets: Assets | None = None,
         address_target: Address | None = None,
         datum_target: PlutusData | None = None,
+        minimum_receive: Assets | None = None,
     ) -> PlutusData:
         ident = bytes.fromhex(self.pool_nft.unit()[64:])
 
@@ -939,7 +955,7 @@ class SundaeSwapV3StableSwap(AbstractStableSwapPoolState):
             ident=ident,
             address_source=address_source,
             in_assets=in_assets,
-            out_assets=out_assets,
+            out_assets=out_assets if minimum_receive is None else minimum_receive,
             fee=self.batcher_fee(in_assets=in_assets, out_assets=out_assets).quantity(),
             address_target=address_target,
             datum_target=datum_target,

--- a/src/charli3_dendrite/dexs/amm/wingriders.py
+++ b/src/charli3_dendrite/dexs/amm/wingriders.py
@@ -388,8 +388,14 @@ class WingRidersV2OrderDatum(OrderDatum):
             compensation_datum = b""
             compensation_datum_type = NoDatum()
 
+        # ``oil`` declares the lovelace the batcher passes through to the beneficiary
+        # (it swaps the rest). A forwarded order must ride the full deposit through to
+        # fund the next hop, so oil follows ``deposit``; a plain owner-paid swap keeps
+        # the standard 2-ADA buffer.
+        oil = deposit.quantity() if address_target is not None else 2000000
+
         return WingRidersV2OrderDatum(
-            oil=2000000,
+            oil=oil,
             beneficiary=beneficiary,
             owner_address=plutus_address,
             compensation_datum=compensation_datum,
@@ -833,12 +839,10 @@ class WingRidersV2CPPState(AbstractConstantProductPoolState):
         out_assets: Assets | None = None,
         extra_assets: Assets | None = None,
     ):
-        merged_assets = in_assets + out_assets
-        if "lovelace" in merged_assets:
-            if merged_assets["lovelace"] <= 250000000:
-                return Assets(lovelace=850000)
-            elif merged_assets["lovelace"] <= 500000000:
-                return Assets(lovelace=1500000)
+        """The V2 batcher charges a flat 2 ADA regardless of swap size (an order
+        fill deducts exactly ``2_000_000`` from the order value; the V1-era ADA
+        size tiers do not apply to V2).
+        """
         return Assets(lovelace=2000000)
 
 
@@ -887,11 +891,12 @@ class WingRidersV2SSPState(AbstractStableSwapPoolState, WingRidersV2CPPState):
         extra_assets: Assets | None = None,
         address_target: Address | None = None,
         datum_target: PlutusData | None = None,
+        minimum_receive: Assets | None = None,
     ) -> PlutusData:
         return self.order_datum_class().create_datum(
             address_source=address_source,
             in_assets=in_assets,
-            out_assets=out_assets,
+            out_assets=out_assets if minimum_receive is None else minimum_receive,
             batcher_fee=self.batcher_fee(
                 in_assets=in_assets,
                 out_assets=out_assets,


### PR DESCRIPTION
## Summary

Three corrections to swap-forwarding order construction, aligned with how the
DEX batchers actually service forwarded orders on mainnet:

- **Minswap V2 receiver carries the datum hash, never the embedded datum.**
  The ExtraDatum receiver field holds a 32-byte hash (`Constr 1 [B <hash>]`
  for a datum-hash output, `Constr 2 [B <hash>]` for an inline output); the
  order validator `un_b_data`'s the field, so an order that embeds the full
  next-hop datum (`Constr 2 [Constr ...]`) can never be spent — neither filled
  nor cancelled. Adds `SundaeV3ReceiverInlineDatumHash` (Constr 2 carrying the
  hash), decodes it ahead of the embedded form in the receiver/refund unions,
  and rewrites `create_datum` to forward a caller-built receiver form or hash a
  raw next-hop datum. The preimage is expected to be published on-chain (e.g. a
  carrier output) for the batcher to attach.
- **Optional `minimum_receive` override on `swap_datum` / `swap_utxo`** (AMM
  classes): decouples the baked on-chain minimum from the exact `out_assets`
  used for fee/deposit sizing, so a caller-relaxed minimum never under-fees the
  order.
- **WingRiders V2 forwarding + fee corrections:** a forwarded order's `oil`
  follows the `deposit` — the batcher passes exactly `oil` lovelace through to
  the beneficiary and swaps the rest — and the V2 batcher fee is a flat 2 ADA
  (an order fill deducts exactly 2_000_000 from the order value; the V1-era ADA
  size tiers do not apply to V2). Plain owner-paid swaps keep the standard
  2-ADA `oil` buffer.

## Test plan

- Byte-exact reconstruction of a real on-chain Minswap V2 forwarded order
  (hash form + published preimage) via `create_datum`.
- Forwarded orders built with these forms were submitted on mainnet and filled
  end-to-end through both hops (Minswap V2 -> SundaeV3 / stableswap terminals,
  WingRiders V2 -> Minswap V2 with the oil-funded cascade); the embedded form
  is reproducibly left unserviced.
- `ruff` / `mypy` parity with the base branch on all touched files (no new
  violations; two pre-existing mypy errors removed by the WingRiders rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)